### PR TITLE
feat: add volume_size parameter to Sandbox.create() and from_pool()

### DIFF
--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -82,19 +82,22 @@ class SandboxClient:
         """
         return f"{self._sandbox_path(name)}/{sub}"
 
-    def claim_from_pool(self, pool: str) -> SandboxInfo:
+    def claim_from_pool(
+        self, pool: str, volume_size: str | None = None
+    ) -> SandboxInfo:
         """Claim a sandbox from a warm pool.
 
         Args:
             pool: Name of the warm pool.
+            volume_size: PVC volume size (e.g. '20Gi').
 
         Returns:
             Information about the claimed sandbox.
         """
-        request = ClaimRequest(pool_name=pool)
+        request = ClaimRequest(pool_name=pool, volume_size=volume_size)
         response = self._http.post(
             f"{self._sandboxes_path()}/claim",
-            json=request.model_dump(by_alias=True),
+            json=request.model_dump(by_alias=True, exclude_none=True),
         )
         # API returns sandboxName for claim endpoint
         sandbox_name = response.get("sandboxName") or response["name"]
@@ -105,12 +108,18 @@ class SandboxClient:
             pool=pool,
         )
 
-    def create(self, image: str, name: str | None = None) -> SandboxInfo:
+    def create(
+        self,
+        image: str,
+        name: str | None = None,
+        volume_size: str | None = None,
+    ) -> SandboxInfo:
         """Create a new sandbox.
 
         Args:
             image: Container image to use.
             name: Optional sandbox name (auto-generated if not provided).
+            volume_size: PVC volume size (e.g. '20Gi').
 
         Returns:
             Information about the created sandbox.
@@ -121,10 +130,10 @@ class SandboxClient:
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
 
-        request = CreateRequest(image=image, name=name)
+        request = CreateRequest(image=image, name=name, volume_size=volume_size)
         response = self._http.post(
             self._sandboxes_path(),
-            json=request.model_dump(),
+            json=request.model_dump(by_alias=True, exclude_none=True),
         )
         # API returns 'phase' instead of 'status' for sandbox phase
         status_str = response.get("status") or response.get("phase")

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -110,6 +110,11 @@ class ClaimRequest(BaseModel):
     pool_name: str = Field(
         ..., serialization_alias="poolName", description="Name of the warm pool"
     )
+    volume_size: str | None = Field(
+        default=None,
+        serialization_alias="volumeSize",
+        description="PVC volume size (e.g. '20Gi')",
+    )
 
 
 class CreateRequest(BaseModel):
@@ -117,6 +122,11 @@ class CreateRequest(BaseModel):
 
     image: str = Field(..., description="Container image to use")
     name: str | None = Field(default=None, description="Optional sandbox name")
+    volume_size: str | None = Field(
+        default=None,
+        serialization_alias="volumeSize",
+        description="PVC volume size (e.g. '20Gi')",
+    )
 
 
 class FileWriteRequest(BaseModel):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -271,6 +271,7 @@ class Sandbox:
         cls,
         pool: str,
         *,
+        volume_size: str | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -284,6 +285,7 @@ class Sandbox:
 
         Args:
             pool: Name of the warm pool.
+            volume_size: PVC volume size (e.g. '20Gi'). If omitted, backend default is used.
             api_url: API URL (default: from PROKUBE_API_URL env var).
             workspace: Workspace (default: from PROKUBE_WORKSPACE env var).
             user_id: User ID (default: from PROKUBE_USER_ID env var).
@@ -306,7 +308,7 @@ class Sandbox:
         )
         client = SandboxClient(config)
         try:
-            info = client.claim_from_pool(pool)
+            info = client.claim_from_pool(pool, volume_size=volume_size)
         except Exception:
             client.close()
             raise
@@ -458,6 +460,7 @@ class Sandbox:
         image: str,
         *,
         name: str | None = None,
+        volume_size: str | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -472,6 +475,7 @@ class Sandbox:
         Args:
             image: Container image to use.
             name: Optional sandbox name (auto-generated if not provided).
+            volume_size: PVC volume size (e.g. '20Gi'). If omitted, backend default is used.
             api_url: API URL (default: from PROKUBE_API_URL env var).
             workspace: Workspace (default: from PROKUBE_WORKSPACE env var).
             user_id: User ID (default: from PROKUBE_USER_ID env var).
@@ -498,7 +502,7 @@ class Sandbox:
         )
         client = SandboxClient(config)
         try:
-            info = client.create(image=image, name=name)
+            info = client.create(image=image, name=name, volume_size=volume_size)
         except Exception:
             client.close()
             raise

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -175,6 +175,115 @@ class TestSandboxCreate:
         sbx._client.close()
 
 
+class TestSandboxCreateWithVolumeSize:
+    """Tests for Sandbox.create() with volume_size."""
+
+    def test_create_with_volume_size(self, mock_env, httpx_mock: HTTPXMock):
+        """Test creating sandbox with volume_size sends volumeSize in body."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            json={"name": "sandbox-vol", "status": "Pending"},
+        )
+
+        sbx = Sandbox.create(image="python:3.10", volume_size="20Gi")
+
+        assert sbx.name == "sandbox-vol"
+
+        import json
+
+        requests = httpx_mock.get_requests()
+        create_request = [r for r in requests if r.method == "POST"][-1]
+        body = json.loads(create_request.content)
+        assert body["volumeSize"] == "20Gi"
+
+        sbx._client.close()
+
+    def test_create_without_volume_size(self, mock_env, httpx_mock: HTTPXMock):
+        """Test creating sandbox without volume_size does not send volumeSize."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            json={"name": "sandbox-novol", "status": "Pending"},
+        )
+
+        sbx = Sandbox.create(image="python:3.10")
+
+        import json
+
+        requests = httpx_mock.get_requests()
+        create_request = [r for r in requests if r.method == "POST"][-1]
+        body = json.loads(create_request.content)
+        assert "volumeSize" not in body
+
+        sbx._client.close()
+
+
+class TestSandboxFromPoolWithVolumeSize:
+    """Tests for Sandbox.from_pool() with volume_size."""
+
+    def test_from_pool_with_volume_size(self, mock_env, httpx_mock: HTTPXMock):
+        """Test claiming from pool with volume_size sends volumeSize in body."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-pool-vol", "status": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool", volume_size="20Gi")
+
+        assert sbx.name == "sandbox-pool-vol"
+
+        import json
+
+        requests = httpx_mock.get_requests()
+        claim_request = [r for r in requests if "/claim" in str(r.url)][-1]
+        body = json.loads(claim_request.content)
+        assert body["poolName"] == "python-pool"
+        assert body["volumeSize"] == "20Gi"
+
+        sbx._client.close()
+
+    def test_from_pool_without_volume_size(self, mock_env, httpx_mock: HTTPXMock):
+        """Test claiming from pool without volume_size does not send volumeSize."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-pool-novol", "status": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+
+        import json
+
+        requests = httpx_mock.get_requests()
+        claim_request = [r for r in requests if "/claim" in str(r.url)][-1]
+        body = json.loads(claim_request.content)
+        assert "volumeSize" not in body
+
+        sbx._client.close()
+
+
 class TestSandboxRunCode:
     """Tests for Sandbox.run_code()."""
 


### PR DESCRIPTION
## Summary

Closes #11

- Added `volume_size: str | None = None` parameter to `Sandbox.create()` and `Sandbox.from_pool()`
- Sends `{"volumeSize": "20Gi"}` in the request body when specified; omits the field entirely when not set (backend uses its default)
- Added `volume_size` field to `CreateRequest` and `ClaimRequest` models with `serialization_alias="volumeSize"`

## Test plan

- [x] `test_create_with_volume_size` — verifies `volumeSize` is sent in create request body
- [x] `test_create_without_volume_size` — verifies `volumeSize` is absent when omitted
- [x] `test_from_pool_with_volume_size` — verifies `volumeSize` is sent in claim request body
- [x] `test_from_pool_without_volume_size` — verifies `volumeSize` is absent when omitted
- [x] All 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)