### PR TITLE
feat: warm pool pods in SandboxPool.create

### DIFF
--- a/src/prokube/sandbox/pool.py
+++ b/src/prokube/sandbox/pool.py
@@ -180,10 +180,13 @@ class SandboxPool:
     ) -> Self:
         """Create a new sandbox pool.
 
-        By default this blocks until the pool is usable end-to-end: it polls
-        until ``ready_replicas >= pool_size`` and then claims a single sandbox
+        By default this makes a best-effort attempt to wait for the new pool
+        to warm up before returning: it polls ``self.refresh()`` until
+        ``ready_replicas >= self._replicas`` (the backend-reported desired
+        count, which may differ from the requested ``pool_size`` if the
+        backend clamps or applies defaults), then claims a single sandbox
         from the fresh pool, runs the same Jupyter-kernel warmup probe that
-        :meth:`Sandbox.wait_until_ready` uses, and kills it. This eliminates
+        :meth:`Sandbox.wait_until_ready` uses, and kills it. This *mitigates*
         the cold-kernel race where a freshly-created pool's pods are
         physically ``Running`` but their ipykernel is still cold (~1-2s), so
         the very first ``Sandbox.from_pool(...).run_code(...)`` after a fresh
@@ -193,6 +196,11 @@ class SandboxPool:
         the time the probe returns the other pool pods have had a similar
         amount of wall-clock time to warm up naturally. This is "Option A"
         from issue #24 — probabilistically safe and cheap.
+
+        Warmup is best-effort: a readiness or probe timeout, or any other
+        warmup-phase exception, is logged via ``logger.warning`` and the pool
+        is still returned. Errors from the underlying pool create API call
+        itself always propagate.
 
         Opt out with ``wait_until_ready=False`` to preserve the previous
         instant-return behaviour. This is the escape hatch for callers who
@@ -245,7 +253,7 @@ class SandboxPool:
             ...     env_vars=[{"name": "FOO", "value": "bar"}],
             ...     secret_refs=["openai-key"],
             ... )
-            >>> # Pool is guaranteed warm — no cold-kernel race on first claim
+            >>> # Best-effort warmed: most calls won't race the cold kernel
             >>> sbx = Sandbox.from_pool("my-pool")
             >>> sbx.run_code("print('hello')").stdout.strip()  # "hello"
         """
@@ -288,27 +296,11 @@ class SandboxPool:
         )
 
         if should_warm:
-            pool._warm_one_pod(
-                ready_timeout=ready_timeout,
-                api_url=api_url,
-                workspace=workspace,
-                user_id=user_id,
-                api_key=api_key,
-                timeout=timeout,
-            )
+            pool._warm_one_pod(ready_timeout=ready_timeout)
 
         return pool
 
-    def _warm_one_pod(
-        self,
-        *,
-        ready_timeout: int,
-        api_url: str | None,
-        workspace: str | None,
-        user_id: str | None,
-        api_key: str | None,
-        timeout: int | None,
-    ) -> None:
+    def _warm_one_pod(self, *, ready_timeout: int) -> None:
         """Wait for the pool to be ready, then warm one pod end-to-end.
 
         Phase 1: poll ``self.refresh()`` until
@@ -375,46 +367,43 @@ class SandboxPool:
             )
             return
 
-        # Phase 2: claim + probe + kill one sandbox. Reuse the same connection
-        # parameters the pool was created with so the probe hits the same
-        # backend / workspace.
+        # Phase 2: claim + probe + kill one sandbox.
         #
         # Sandbox.wait_until_ready needs an integer second timeout. If less
         # than 1 second remains we cannot probe without overrunning the
         # caller's ready_timeout, so we skip the probe entirely (consistent
-        # with how Sandbox._warmup_kernel handles its own remaining budget).
-        remaining = deadline - time.monotonic()
-        if remaining < 1:
+        # with how Sandbox._warmup_kernel handles its own remaining budget)
+        # AND avoid claiming a sandbox we'd immediately have to kill.
+        probe_budget = int(deadline - time.monotonic())
+        if probe_budget < 1:
             logger.warning(
-                "SandboxPool %s warmup: no time left after readiness poll; "
-                "skipping warmup probe",
+                "SandboxPool %s warmup: less than 1s remains after readiness "
+                "poll; skipping warmup probe (no claim made)",
                 self._name,
             )
             return
+
+        # Reuse the resolved Config from the pool's existing PoolClient so
+        # the probe definitely hits the same backend/workspace/auth as the
+        # pool itself, even if the surrounding env vars have changed since
+        # SandboxPool.create was first called.
+        pool_config = self._client.config
 
         sbx = None
         try:
             sbx = Sandbox.from_pool(
                 self._name,
-                api_url=api_url,
-                workspace=workspace,
-                user_id=user_id,
-                api_key=api_key,
-                timeout=timeout,
+                api_url=pool_config.api_url,
+                workspace=pool_config.workspace,
+                user_id=pool_config.user_id,
+                api_key=pool_config.api_key,
+                timeout=pool_config.timeout,
             )
             # Sandbox.wait_until_ready runs the cold-kernel warmup probe and
             # is itself best-effort on probe timeout — it logs and returns.
             # Cap its budget by the remaining pool-level deadline so it can
             # never exceed the caller's ready_timeout.
-            probe_budget = int(deadline - time.monotonic())
-            if probe_budget < 1:
-                logger.warning(
-                    "SandboxPool %s warmup: less than 1s remains before "
-                    "claiming the probe sandbox; skipping warmup probe",
-                    self._name,
-                )
-            else:
-                sbx.wait_until_ready(timeout=probe_budget)
+            sbx.wait_until_ready(timeout=probe_budget)
         except Exception as exc:  # noqa: BLE001 - best-effort
             logger.warning(
                 "SandboxPool %s warmup: probe sandbox failed (%s); "

--- a/src/prokube/sandbox/pool.py
+++ b/src/prokube/sandbox/pool.py
@@ -219,9 +219,12 @@ class SandboxPool:
                 If False, return immediately after the pool CR is created.
             ready_timeout: Maximum seconds to wait for the pool to become
                 ready and for the warmup probe to finish. Applied as a single
-                overall budget across both phases. On timeout the method logs
-                a warning and returns the pool anyway — best-effort, matching
-                :meth:`Sandbox.wait_until_ready`.
+                overall budget across both phases. On timeout (or any other
+                failure during warmup) the method logs a warning and returns
+                the pool anyway — the warmup is purely best-effort. Note this
+                is different from :meth:`Sandbox.wait_until_ready`, which
+                *raises* :class:`SandboxTimeoutError` on a pod-not-ready
+                timeout; only its kernel warmup probe phase is best-effort.
             api_url: API URL (default: from PROKUBE_API_URL env var).
             workspace: Workspace (default: from PROKUBE_WORKSPACE env var).
             user_id: User ID (default: from PROKUBE_USER_ID env var).
@@ -286,7 +289,6 @@ class SandboxPool:
 
         if should_warm:
             pool._warm_one_pod(
-                pool_size=pool_size,
                 ready_timeout=ready_timeout,
                 api_url=api_url,
                 workspace=workspace,
@@ -300,7 +302,6 @@ class SandboxPool:
     def _warm_one_pod(
         self,
         *,
-        pool_size: int,
         ready_timeout: int,
         api_url: str | None,
         workspace: str | None,
@@ -310,17 +311,18 @@ class SandboxPool:
     ) -> None:
         """Wait for the pool to be ready, then warm one pod end-to-end.
 
-        Phase 1: poll ``self.refresh()`` until ``ready_replicas >= pool_size``
-        or ``ready_timeout`` is exhausted.
+        Phase 1: poll ``self.refresh()`` until
+        ``ready_replicas >= self._replicas`` (the *actual* desired count from
+        the backend, which may differ from the requested ``pool_size`` if the
+        backend clamps or applies defaults) or ``ready_timeout`` is exhausted.
 
         Phase 2: claim one sandbox from the pool, call ``wait_until_ready``
         on it (which runs the cold-kernel probe), then kill it.
 
         Any failure in either phase is swallowed with a warning — this is a
-        best-effort warmup, exactly like :meth:`Sandbox.wait_until_ready`.
-        The pool CR itself has already been created before this is called,
-        so the caller still gets a usable :class:`SandboxPool` handle even
-        if the warmup cannot complete.
+        best-effort warmup. The pool CR itself has already been created before
+        this is called, so the caller still gets a usable :class:`SandboxPool`
+        handle even if the warmup cannot complete.
         """
         # Local import to avoid a circular import at module load time:
         # sandbox.py imports nothing from pool.py, but pool.py -> sandbox.py
@@ -345,7 +347,11 @@ class SandboxPool:
                         exc,
                     )
                     return
-                if self._ready_replicas >= pool_size:
+                # Compare against the backend-reported desired replica count
+                # (self._replicas), not the requested pool_size argument: if
+                # the backend clamps or applies a default, the request value
+                # may never be reached even though the pool is fully ready.
+                if self._ready_replicas >= self._replicas:
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
@@ -354,7 +360,7 @@ class SandboxPool:
                         "ready_replicas>=%d within %ds (have %d); "
                         "skipping warmup probe",
                         self._name,
-                        pool_size,
+                        self._replicas,
                         ready_timeout,
                         self._ready_replicas,
                     )
@@ -372,8 +378,13 @@ class SandboxPool:
         # Phase 2: claim + probe + kill one sandbox. Reuse the same connection
         # parameters the pool was created with so the probe hits the same
         # backend / workspace.
+        #
+        # Sandbox.wait_until_ready needs an integer second timeout. If less
+        # than 1 second remains we cannot probe without overrunning the
+        # caller's ready_timeout, so we skip the probe entirely (consistent
+        # with how Sandbox._warmup_kernel handles its own remaining budget).
         remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if remaining < 1:
             logger.warning(
                 "SandboxPool %s warmup: no time left after readiness poll; "
                 "skipping warmup probe",
@@ -395,8 +406,15 @@ class SandboxPool:
             # is itself best-effort on probe timeout — it logs and returns.
             # Cap its budget by the remaining pool-level deadline so it can
             # never exceed the caller's ready_timeout.
-            probe_budget = max(1, int(deadline - time.monotonic()))
-            sbx.wait_until_ready(timeout=probe_budget)
+            probe_budget = int(deadline - time.monotonic())
+            if probe_budget < 1:
+                logger.warning(
+                    "SandboxPool %s warmup: less than 1s remains before "
+                    "claiming the probe sandbox; skipping warmup probe",
+                    self._name,
+                )
+            else:
+                sbx.wait_until_ready(timeout=probe_budget)
         except Exception as exc:  # noqa: BLE001 - best-effort
             logger.warning(
                 "SandboxPool %s warmup: probe sandbox failed (%s); "
@@ -416,6 +434,14 @@ class SandboxPool:
                         sbx.name,
                         exc,
                     )
+                    # kill() leaves the underlying HTTP client open if the
+                    # delete request fails (kill() only closes the client
+                    # after a successful delete). Close it explicitly here
+                    # to avoid leaking connections in long-lived processes.
+                    try:
+                        sbx._client.close()
+                    except Exception:  # noqa: BLE001
+                        pass
 
     @classmethod
     def list(

--- a/src/prokube/sandbox/pool.py
+++ b/src/prokube/sandbox/pool.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import sys
+import time
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -12,6 +14,8 @@ else:
 from prokube.common.config import Config
 from prokube.common.exceptions import SandboxError
 from prokube.sandbox.pool_client import PoolClient
+
+logger = logging.getLogger(__name__)
 
 
 class SandboxPool:
@@ -166,6 +170,8 @@ class SandboxPool:
         allow_internet_access: bool | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
+        wait_until_ready: bool = True,
+        ready_timeout: int = 300,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -173,6 +179,28 @@ class SandboxPool:
         timeout: int | None = None,
     ) -> Self:
         """Create a new sandbox pool.
+
+        By default this blocks until the pool is usable end-to-end: it polls
+        until ``ready_replicas >= pool_size`` and then claims a single sandbox
+        from the fresh pool, runs the same Jupyter-kernel warmup probe that
+        :meth:`Sandbox.wait_until_ready` uses, and kills it. This eliminates
+        the cold-kernel race where a freshly-created pool's pods are
+        physically ``Running`` but their ipykernel is still cold (~1-2s), so
+        the very first ``Sandbox.from_pool(...).run_code(...)`` after a fresh
+        ``SandboxPool.create(...)`` could race and return empty stdout.
+
+        The single probe's wall-clock is itself the cold-kernel window, so by
+        the time the probe returns the other pool pods have had a similar
+        amount of wall-clock time to warm up naturally. This is "Option A"
+        from issue #24 — probabilistically safe and cheap.
+
+        Opt out with ``wait_until_ready=False`` to preserve the previous
+        instant-return behaviour. This is the escape hatch for callers who
+        explicitly don't want the wait (e.g. tests, or callers that will do
+        their own readiness handling).
+
+        ``Sandbox.from_pool`` is intentionally unchanged by this method — the
+        hot path of claiming from an already-warm pool stays fast.
 
         Args:
             name: Pool name.
@@ -186,6 +214,14 @@ class SandboxPool:
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into pool
                 sandboxes.
+            wait_until_ready: If True (default), block until the pool is ready
+                and warm one pod via the cold-kernel probe before returning.
+                If False, return immediately after the pool CR is created.
+            ready_timeout: Maximum seconds to wait for the pool to become
+                ready and for the warmup probe to finish. Applied as a single
+                overall budget across both phases. On timeout the method logs
+                a warning and returns the pool anyway — best-effort, matching
+                :meth:`Sandbox.wait_until_ready`.
             api_url: API URL (default: from PROKUBE_API_URL env var).
             workspace: Workspace (default: from PROKUBE_WORKSPACE env var).
             user_id: User ID (default: from PROKUBE_USER_ID env var).
@@ -206,7 +242,14 @@ class SandboxPool:
             ...     env_vars=[{"name": "FOO", "value": "bar"}],
             ...     secret_refs=["openai-key"],
             ... )
+            >>> # Pool is guaranteed warm — no cold-kernel race on first claim
+            >>> sbx = Sandbox.from_pool("my-pool")
+            >>> sbx.run_code("print('hello')").stdout.strip()  # "hello"
         """
+        # Local name for the flag so there's no confusion with the similarly
+        # named Sandbox.wait_until_ready method used below.
+        should_warm = wait_until_ready
+
         config = cls._build_config(
             api_url=api_url,
             workspace=workspace,
@@ -230,7 +273,7 @@ class SandboxPool:
             client.close()
             raise
 
-        return cls(
+        pool = cls(
             name=info.name,
             workspace=info.workspace,
             client=client,
@@ -240,6 +283,139 @@ class SandboxPool:
             cpu=info.cpu,
             memory=info.memory,
         )
+
+        if should_warm:
+            pool._warm_one_pod(
+                pool_size=pool_size,
+                ready_timeout=ready_timeout,
+                api_url=api_url,
+                workspace=workspace,
+                user_id=user_id,
+                api_key=api_key,
+                timeout=timeout,
+            )
+
+        return pool
+
+    def _warm_one_pod(
+        self,
+        *,
+        pool_size: int,
+        ready_timeout: int,
+        api_url: str | None,
+        workspace: str | None,
+        user_id: str | None,
+        api_key: str | None,
+        timeout: int | None,
+    ) -> None:
+        """Wait for the pool to be ready, then warm one pod end-to-end.
+
+        Phase 1: poll ``self.refresh()`` until ``ready_replicas >= pool_size``
+        or ``ready_timeout`` is exhausted.
+
+        Phase 2: claim one sandbox from the pool, call ``wait_until_ready``
+        on it (which runs the cold-kernel probe), then kill it.
+
+        Any failure in either phase is swallowed with a warning — this is a
+        best-effort warmup, exactly like :meth:`Sandbox.wait_until_ready`.
+        The pool CR itself has already been created before this is called,
+        so the caller still gets a usable :class:`SandboxPool` handle even
+        if the warmup cannot complete.
+        """
+        # Local import to avoid a circular import at module load time:
+        # sandbox.py imports nothing from pool.py, but pool.py -> sandbox.py
+        # would pull the SandboxClient stack eagerly and complicate test
+        # isolation for pool-only tests. Importing here keeps the hot path
+        # (from_pool) cold-import-free for users who never call create().
+        from prokube.sandbox.sandbox import Sandbox
+
+        deadline = time.monotonic() + ready_timeout
+        poll_interval = 2.0
+
+        # Phase 1: pool readiness.
+        try:
+            while True:
+                try:
+                    self.refresh()
+                except Exception as exc:  # noqa: BLE001 - best-effort
+                    logger.warning(
+                        "SandboxPool %s warmup: refresh failed (%s); "
+                        "skipping warmup probe",
+                        self._name,
+                        exc,
+                    )
+                    return
+                if self._ready_replicas >= pool_size:
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "SandboxPool %s warmup: pool did not reach "
+                        "ready_replicas>=%d within %ds (have %d); "
+                        "skipping warmup probe",
+                        self._name,
+                        pool_size,
+                        ready_timeout,
+                        self._ready_replicas,
+                    )
+                    return
+                time.sleep(min(poll_interval, remaining))
+        except Exception as exc:  # noqa: BLE001 - best-effort
+            logger.warning(
+                "SandboxPool %s warmup: unexpected error while waiting for "
+                "pool readiness (%s); skipping warmup probe",
+                self._name,
+                exc,
+            )
+            return
+
+        # Phase 2: claim + probe + kill one sandbox. Reuse the same connection
+        # parameters the pool was created with so the probe hits the same
+        # backend / workspace.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(
+                "SandboxPool %s warmup: no time left after readiness poll; "
+                "skipping warmup probe",
+                self._name,
+            )
+            return
+
+        sbx = None
+        try:
+            sbx = Sandbox.from_pool(
+                self._name,
+                api_url=api_url,
+                workspace=workspace,
+                user_id=user_id,
+                api_key=api_key,
+                timeout=timeout,
+            )
+            # Sandbox.wait_until_ready runs the cold-kernel warmup probe and
+            # is itself best-effort on probe timeout — it logs and returns.
+            # Cap its budget by the remaining pool-level deadline so it can
+            # never exceed the caller's ready_timeout.
+            probe_budget = max(1, int(deadline - time.monotonic()))
+            sbx.wait_until_ready(timeout=probe_budget)
+        except Exception as exc:  # noqa: BLE001 - best-effort
+            logger.warning(
+                "SandboxPool %s warmup: probe sandbox failed (%s); "
+                "pool is returned anyway",
+                self._name,
+                exc,
+            )
+        finally:
+            if sbx is not None:
+                try:
+                    sbx.kill()
+                except Exception as exc:  # noqa: BLE001 - best-effort
+                    logger.warning(
+                        "SandboxPool %s warmup: failed to kill probe "
+                        "sandbox %s (%s); leaking one claim",
+                        self._name,
+                        sbx.name,
+                        exc,
+                    )
 
     @classmethod
     def list(

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,7 +1,9 @@
 """Tests for PoolClient and SandboxPool."""
 
 import json
+import re
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -9,6 +11,19 @@ from prokube.common.config import Config
 from prokube.common.exceptions import SandboxError
 from prokube.sandbox.pool import SandboxPool
 from prokube.sandbox.pool_client import PoolClient
+
+_WARMUP_MARKER_RE = re.compile(r'print\("(__pk_warmup_[0-9a-f]+__)"\)')
+
+
+def _extract_marker(request: httpx.Request) -> str | None:
+    """Extract the warmup marker from an /exec request body, if present."""
+    try:
+        body = json.loads(request.content)
+    except ValueError:
+        return None
+    code = body.get("code", "")
+    match = _WARMUP_MARKER_RE.search(code)
+    return match.group(1) if match else None
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +264,7 @@ class TestSandboxPoolCreateExtras:
             allow_internet_access=False,
             env_vars=[{"name": "DEBUG", "value": "1"}],
             secret_refs=["db-creds"],
+            wait_until_ready=False,
         )
 
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
@@ -272,6 +288,7 @@ class TestSandboxPoolCreateExtras:
             pool_size=3,
             cpu="2",
             memory="4Gi",
+            wait_until_ready=False,
         )
 
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
@@ -423,6 +440,7 @@ class TestSandboxPoolCreate:
             pool_size=3,
             cpu="2",
             memory="4Gi",
+            wait_until_ready=False,
         )
 
         assert pool.name == "python-pool"
@@ -430,6 +448,217 @@ class TestSandboxPoolCreate:
         assert pool.pool_size == 3
         assert pool.ready_replicas == 2
         assert pool.image == "pk-sandbox-base:latest"
+        pool._client.close()
+
+
+class TestSandboxPoolCreateWarmup:
+    """Tests for the warm-one-pod behaviour of SandboxPool.create()."""
+
+    # Pool response where the pool is already fully ready on the first refresh.
+    _READY_POOL_RESPONSE = {
+        "name": "python-pool",
+        "replicas": 1,
+        "readyReplicas": 1,
+        "image": "pk-sandbox-base:latest",
+        "cpu": "2",
+        "memory": "4Gi",
+    }
+
+    def _mock_warmup_happy_path(
+        self, httpx_mock: HTTPXMock, probe_marker_echo: bool = True
+    ) -> dict:
+        """Mock the full create -> refresh -> claim -> exec -> delete chain.
+
+        Returns a dict with counters the test can inspect (number of /exec
+        calls made).
+
+        Args:
+            probe_marker_echo: When True the /exec callback echoes the
+                warmup marker back and the probe succeeds on the first try.
+                When False it returns empty stdout so the probe retries
+                until the deadline trips.
+        """
+        # Version check: hit twice (once for the PoolClient, once for the
+        # SandboxClient spun up by Sandbox.from_pool).
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+            is_reusable=True,
+        )
+        # Pool create.
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            json=self._READY_POOL_RESPONSE,
+        )
+        # Pool refresh — reusable so the polling loop can read it repeatedly.
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            json=self._READY_POOL_RESPONSE,
+            is_reusable=True,
+        )
+        # Claim a sandbox out of the pool.
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-warmup", "status": "Running"},
+        )
+        # wait_until_ready refreshes the sandbox before running the probe.
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-warmup",
+            json={"name": "sandbox-warmup", "phase": "Running"},
+            is_reusable=True,
+        )
+
+        counters: dict[str, int] = {"exec": 0}
+
+        def _probe_callback(request: httpx.Request) -> httpx.Response:
+            counters["exec"] += 1
+            marker = _extract_marker(request) or ""
+            stdout = f"{marker}\n" if probe_marker_echo else ""
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": stdout,
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                },
+            )
+
+        httpx_mock.add_callback(
+            _probe_callback,
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-warmup/exec",
+            is_reusable=True,
+        )
+        # kill() at the end of the warmup probe.
+        httpx_mock.add_response(
+            method="DELETE",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-warmup",
+            status_code=204,
+        )
+        return counters
+
+    def test_sandbox_pool_create_warms_pods(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Default create should claim+probe+kill one sandbox before returning."""
+        counters = self._mock_warmup_happy_path(httpx_mock)
+
+        pool = SandboxPool.create(
+            name="python-pool",
+            image="pk-sandbox-base:latest",
+            pool_size=1,
+            cpu="2",
+            memory="4Gi",
+        )
+
+        # The probe must have been invoked at least once — this is the whole
+        # point of the warmup, and this is what makes from_pool safe.
+        assert counters["exec"] >= 1, (
+            "SandboxPool.create(wait_until_ready=True) should run the "
+            "warmup probe before returning"
+        )
+
+        # The probe sandbox should have been killed.
+        delete_reqs = [
+            r
+            for r in httpx_mock.get_requests()
+            if r.method == "DELETE" and "sandboxes/sandbox-warmup" in str(r.url)
+        ]
+        assert len(delete_reqs) == 1, (
+            "warmup should kill the probe sandbox exactly once"
+        )
+
+        assert pool.name == "python-pool"
+        pool._client.close()
+
+    def test_sandbox_pool_create_opt_out(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """wait_until_ready=False must preserve instant-return behaviour."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            json=POOL_RESPONSE,
+        )
+
+        pool = SandboxPool.create(
+            name="python-pool",
+            image="pk-sandbox-base:latest",
+            pool_size=3,
+            cpu="2",
+            memory="4Gi",
+            wait_until_ready=False,
+        )
+
+        # Absolutely no probe, refresh, claim, or kill calls should have
+        # happened — only the version check and the pool POST.
+        requests = httpx_mock.get_requests()
+        exec_reqs = [r for r in requests if "/exec" in str(r.url)]
+        claim_reqs = [r for r in requests if "/sandboxes/claim" in str(r.url)]
+        refresh_reqs = [
+            r
+            for r in requests
+            if r.method == "GET"
+            and "/sandbox-pools/python-pool" in str(r.url)
+        ]
+        assert exec_reqs == [], "opt-out must not run warmup probe"
+        assert claim_reqs == [], "opt-out must not claim a probe sandbox"
+        assert refresh_reqs == [], "opt-out must not poll pool readiness"
+
+        assert pool.name == "python-pool"
+        pool._client.close()
+
+    def test_sandbox_pool_create_warmup_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Probe timeout must be best-effort: log and return the pool anyway."""
+        # Make time.monotonic() advance quickly so the probe deadline trips
+        # after a couple of attempts instead of burning real wall-clock time.
+        import time as _time
+
+        real_monotonic = _time.monotonic
+        start = real_monotonic()
+        tick = {"n": 0}
+
+        def fake_monotonic() -> float:
+            # Each call advances virtual time by 1s. The initial budget is
+            # the one we pass in (ready_timeout=30 below), so the probe gets
+            # a handful of attempts before the deadline is exhausted.
+            tick["n"] += 1
+            return start + tick["n"] * 1.0
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        # Probe never echoes the marker, so wait_until_ready will exhaust its
+        # budget and log-and-return.
+        counters = self._mock_warmup_happy_path(
+            httpx_mock, probe_marker_echo=False
+        )
+
+        # Should NOT raise even though the probe never succeeds. Matches
+        # Sandbox.wait_until_ready best-effort semantics.
+        pool = SandboxPool.create(
+            name="python-pool",
+            image="pk-sandbox-base:latest",
+            pool_size=1,
+            cpu="2",
+            memory="4Gi",
+            ready_timeout=30,
+        )
+
+        # The probe must have been attempted at least once before the
+        # deadline tripped — this proves we actually ran the warmup probe
+        # rather than bailing out early.
+        assert counters["exec"] >= 1
+        assert pool.name == "python-pool"
         pool._client.close()
 
 
@@ -620,6 +849,7 @@ class TestSandboxPoolApiKeyRouting:
             api_url="https://test.example.com",
             workspace="ws",
             api_key="test-key",
+            wait_until_ready=False,
         )
 
         requests = httpx_mock.get_requests()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -616,11 +616,12 @@ class TestSandboxPoolCreateWarmup:
         pool._client.close()
 
     def test_sandbox_pool_create_warmup_timeout(
-        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+        self, mock_env, monkeypatch, caplog, httpx_mock: HTTPXMock
     ):
         """Probe timeout must be best-effort: log and return the pool anyway."""
         # Make time.monotonic() advance quickly so the probe deadline trips
         # after a couple of attempts instead of burning real wall-clock time.
+        import logging
         import time as _time
 
         real_monotonic = _time.monotonic
@@ -645,20 +646,32 @@ class TestSandboxPoolCreateWarmup:
 
         # Should NOT raise even though the probe never succeeds. Matches
         # Sandbox.wait_until_ready best-effort semantics.
-        pool = SandboxPool.create(
-            name="python-pool",
-            image="pk-sandbox-base:latest",
-            pool_size=1,
-            cpu="2",
-            memory="4Gi",
-            ready_timeout=30,
-        )
+        with caplog.at_level(logging.WARNING, logger="prokube.sandbox.sandbox"):
+            pool = SandboxPool.create(
+                name="python-pool",
+                image="pk-sandbox-base:latest",
+                pool_size=1,
+                cpu="2",
+                memory="4Gi",
+                ready_timeout=30,
+            )
 
         # The probe must have been attempted at least once before the
         # deadline tripped — this proves we actually ran the warmup probe
         # rather than bailing out early.
         assert counters["exec"] >= 1
         assert pool.name == "python-pool"
+        # Sandbox._warmup_kernel must have logged the "did not echo marker
+        # within deadline" warning. Without this assertion, the test would
+        # silently pass even if the probe magically succeeded.
+        assert any(
+            "warmup probe did not echo marker" in record.message
+            for record in caplog.records
+        ), (
+            "expected Sandbox._warmup_kernel to log a warning when the "
+            "probe deadline is exhausted; saw: "
+            f"{[record.message for record in caplog.records]}"
+        )
         pool._client.close()
 
 


### PR DESCRIPTION
Implements #24 (Option A: single-pod probe at create time).

## Changes
- SandboxPool.create gains `wait_until_ready: bool = True` and `ready_timeout: int = 300` keyword-only params
- When True (default): poll pool readiness, claim one sandbox, run the existing warmup probe via `sbx.wait_until_ready()`, kill it
- When False: preserves today's instant-return behaviour
- On warmup timeout: logs a warning and returns the pool anyway (matches Sandbox.wait_until_ready best-effort semantics)

## Out of scope
- `Sandbox.from_pool` is unchanged - the hot path stays fast
- `Sandbox.wait_until_ready` is unchanged - reuses the existing probe
- No backend changes

## Tests
- test_sandbox_pool_create_warms_pods - happy path
- test_sandbox_pool_create_opt_out - wait_until_ready=False bypass
- test_sandbox_pool_create_warmup_timeout - best-effort on probe timeout

Closes #24