### PR TITLE
fix: honor pool-resume hint in SDK

### DIFF
--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -224,7 +224,7 @@ class SandboxClient:
                 raise SandboxError(str(e), status_code=409) from e
             raise
 
-    def resume(self, name: str) -> None:
+    def resume(self, name: str) -> SandboxInfo:
         """Resume a paused sandbox.
 
         A new pod starts with the same PVC mounts at /workspace and /home/agent.
@@ -236,11 +236,24 @@ class SandboxClient:
             SandboxError: If sandbox is not in Paused state (HTTP 409).
         """
         try:
-            self._http.post(self._sandbox_sub_path(name, "resume"))
+            response = self._http.post(self._sandbox_sub_path(name, "resume"))
         except ProKubeError as e:
             if e.status_code == 409:
                 raise SandboxError(str(e), status_code=409) from e
             raise
+
+        return SandboxInfo(
+            name=response.get("name", name),
+            workspace=self.config.workspace,
+            status=_parse_status(
+                response.get("status") or response.get("phase"),
+                SandboxStatus.PENDING,
+            ),
+            image=response.get("image"),
+            pool=response.get("poolName") or response.get("pool"),
+            created_at=response.get("createdAt") or response.get("created_at"),
+            resumed_from_pool=response.get("resumedFromPool", False),
+        )
 
     def delete(self, name: str) -> None:
         """Delete a sandbox.

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -242,13 +242,14 @@ class SandboxClient:
                 raise SandboxError(str(e), status_code=409) from e
             raise
 
+        status_str = response.get("phase") or response.get("status")
+        if isinstance(status_str, str) and status_str.lower() == "ok":
+            status_str = None
+
         return SandboxInfo(
             name=response.get("name", name),
             workspace=self.config.workspace,
-            status=_parse_status(
-                response.get("status") or response.get("phase"),
-                SandboxStatus.PENDING,
-            ),
+            status=_parse_status(status_str, SandboxStatus.PENDING),
             image=response.get("image"),
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -30,6 +30,10 @@ class SandboxInfo(BaseModel):
     image: str | None = Field(default=None, description="Container image")
     pool: str | None = Field(default=None, description="WarmPool name if claimed")
     created_at: str | None = Field(default=None, description="Creation timestamp")
+    resumed_from_pool: bool = Field(
+        default=False,
+        description="True when a resume response came from a warm-pool swap",
+    )
 
 
 class CommandResult(BaseModel):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -229,14 +229,22 @@ class Sandbox:
                 while waiting for it to become ready.
         """
         self._check_not_killed()
-        poll_interval = 2
+        poll_interval = 0.5
         deadline = time.monotonic() + timeout
         while True:
             self.refresh()
             if self._status == SandboxStatus.RUNNING:
                 if self._skip_next_warmup:
-                    self._skip_next_warmup = False
-                    return
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        self._skip_next_warmup = False
+                        return
+                    time.sleep(min(poll_interval, remaining))
+                    self.refresh()
+                    if self._status == SandboxStatus.RUNNING:
+                        self._skip_next_warmup = False
+                        return
+                    continue
                 self._warmup_kernel(deadline)
                 return
             if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -85,6 +85,7 @@ class Sandbox:
         self._pool = pool
         self._image = image
         self._killed = False
+        self._skip_next_warmup = False
 
         # Initialize helpers with killed-state check callback
         self._commands = CommandRunner(client, name, self._check_not_killed)
@@ -210,8 +211,9 @@ class Sandbox:
             SandboxError: If sandbox is not in Paused state.
         """
         self._check_not_killed()
-        self._client.resume(self._name)
-        self._status = SandboxStatus.PENDING
+        info = self._client.resume(self._name)
+        self._status = info.status
+        self._skip_next_warmup = info.resumed_from_pool
         # New pod means previous Jupyter session is invalid.
         self._code.reset_session()
 
@@ -232,6 +234,9 @@ class Sandbox:
         while True:
             self.refresh()
             if self._status == SandboxStatus.RUNNING:
+                if self._skip_next_warmup:
+                    self._skip_next_warmup = False
+                    return
                 self._warmup_kernel(deadline)
                 return
             if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -235,16 +235,8 @@ class Sandbox:
             self.refresh()
             if self._status == SandboxStatus.RUNNING:
                 if self._skip_next_warmup:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        self._skip_next_warmup = False
-                        return
-                    time.sleep(min(poll_interval, remaining))
-                    self.refresh()
-                    if self._status == SandboxStatus.RUNNING:
-                        self._skip_next_warmup = False
-                        return
-                    continue
+                    self._skip_next_warmup = False
+                    return
                 self._warmup_kernel(deadline)
                 return
             if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -165,6 +165,24 @@ class TestClientResume:
         assert info.resumed_from_pool is False
         client.close()
 
+    def test_resume_legacy_ok_status_defaults_to_pending(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            json={"status": "ok"},
+        )
+
+        client = SandboxClient(config)
+        info = client.resume("my-sandbox")
+
+        assert info.name == "my-sandbox"
+        assert info.status == SandboxStatus.PENDING
+        assert info.resumed_from_pool is False
+        client.close()
+
     def test_resume_parses_pool_resume_hint(self, config, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
@@ -279,7 +297,9 @@ class TestSandboxResume:
 
         sbx._client.close()
 
-    def test_resume_from_pool_skips_wait_warmup(self, mock_env, monkeypatch, httpx_mock: HTTPXMock):
+    def test_resume_from_pool_skips_wait_warmup(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
         monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
@@ -292,11 +312,6 @@ class TestSandboxResume:
             method="POST",
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Running", "resumedFromPool": True},
-        )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -320,9 +335,10 @@ class TestSandboxResume:
         exec_requests = [
             r
             for r in requests
-            if r.method == "POST" and str(r.url).endswith("/sandboxes/sandbox-test/exec")
+            if r.method == "POST"
+            and str(r.url).endswith("/sandboxes/sandbox-test/exec")
         ]
-        assert len(get_requests) == 2
+        assert len(get_requests) == 1
         assert not exec_requests
 
         sbx._client.close()
@@ -415,11 +431,6 @@ class TestWaitUntilReady:
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Running"},
-        )
 
         sbx = Sandbox.from_pool("python-pool")
         sbx.pause()
@@ -432,7 +443,7 @@ class TestWaitUntilReady:
             for r in requests
             if r.method == "GET" and "/sandboxes/sandbox-test" in str(r.url)
         ]
-        assert len(get_requests) == 2
+        assert len(get_requests) == 1
         sbx._client.close()
 
     def test_wait_until_ready_warms_kernel_on_cold_start(

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -150,16 +150,34 @@ class TestClientResume:
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
-            json={"status": "ok"},
+            json={"name": "my-sandbox", "phase": "Pending", "resumedFromPool": False},
         )
 
         client = SandboxClient(config)
-        client.resume("my-sandbox")
+        info = client.resume("my-sandbox")
 
         requests = httpx_mock.get_requests()
         resume_req = [r for r in requests if "/resume" in str(r.url)]
         assert len(resume_req) == 1
         assert resume_req[0].method == "POST"
+        assert info.name == "my-sandbox"
+        assert info.status == SandboxStatus.PENDING
+        assert info.resumed_from_pool is False
+        client.close()
+
+    def test_resume_parses_pool_resume_hint(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            json={"name": "my-sandbox", "phase": "Running", "resumedFromPool": True},
+        )
+
+        client = SandboxClient(config)
+        info = client.resume("my-sandbox")
+
+        assert info.status == SandboxStatus.RUNNING
+        assert info.resumed_from_pool is True
         client.close()
 
     def test_resume_conflict_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
@@ -249,7 +267,7 @@ class TestSandboxResume:
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
-            json={"status": "ok"},
+            json={"name": "sandbox-test", "phase": "Pending", "resumedFromPool": False},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -258,6 +276,48 @@ class TestSandboxResume:
 
         sbx.resume()
         assert sbx.status == "Pending"
+
+        sbx._client.close()
+
+    def test_resume_from_pool_skips_wait_warmup(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            json={"status": "ok"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            json={"name": "sandbox-test", "phase": "Running", "resumedFromPool": True},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.pause()
+        sbx.resume()
+
+        assert sbx.status == "Running"
+        sbx.wait_until_ready(timeout=5)
+
+        requests = httpx_mock.get_requests()
+        get_requests = [
+            r
+            for r in requests
+            if r.method == "GET" and "/sandboxes/sandbox-test" in str(r.url)
+        ]
+        exec_requests = [
+            r
+            for r in requests
+            if r.method == "POST" and str(r.url).endswith("/sandboxes/sandbox-test/exec")
+        ]
+        assert len(get_requests) == 1
+        assert not exec_requests
 
         sbx._client.close()
 

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -279,7 +279,8 @@ class TestSandboxResume:
 
         sbx._client.close()
 
-    def test_resume_from_pool_skips_wait_warmup(self, mock_env, httpx_mock: HTTPXMock):
+    def test_resume_from_pool_skips_wait_warmup(self, mock_env, monkeypatch, httpx_mock: HTTPXMock):
+        monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
@@ -291,6 +292,11 @@ class TestSandboxResume:
             method="POST",
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Running", "resumedFromPool": True},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -316,7 +322,7 @@ class TestSandboxResume:
             for r in requests
             if r.method == "POST" and str(r.url).endswith("/sandboxes/sandbox-test/exec")
         ]
-        assert len(get_requests) == 1
+        assert len(get_requests) == 2
         assert not exec_requests
 
         sbx._client.close()
@@ -386,6 +392,47 @@ class TestWaitUntilReady:
         sbx.wait_until_ready(timeout=10)
         assert sbx.status == "Running"
 
+        sbx._client.close()
+
+    def test_wait_until_ready_pool_resume_requires_confirmed_running(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            json={"status": "ok"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            json={"name": "sandbox-test", "phase": "Paused", "resumedFromPool": True},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.pause()
+        sbx.resume()
+        sbx.wait_until_ready(timeout=10)
+
+        requests = httpx_mock.get_requests()
+        get_requests = [
+            r
+            for r in requests
+            if r.method == "GET" and "/sandboxes/sandbox-test" in str(r.url)
+        ]
+        assert len(get_requests) == 2
         sbx._client.close()
 
     def test_wait_until_ready_warms_kernel_on_cold_start(


### PR DESCRIPTION
## Summary
- parse sandbox resume responses instead of discarding them
- carry the backend `resumedFromPool` hint into the SDK sandbox state
- skip the Jupyter warmup probe on the first `wait_until_ready()` after a warm-pool resume

## Testing
- `pytest tests/test_pause_resume.py tests/test_sandbox.py tests/test_client.py -q`
- `PROKUBE_API_URL="https://more-butterfly.prokube.cloud/pkui" PROKUBE_WORKSPACE="experiments" PROKUBE_API_KEY=<redacted> SANDBOX_POOL="test-pool" SANDBOX_IMAGE="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v08-04-2026" pytest ../pkui/worktrees/integration-sandbox-check/tests/e2e/test_sandbox.py -k "warm_pool_pause_resume" -v -s`
- `PROKUBE_API_URL="https://more-butterfly.prokube.cloud/pkui" PROKUBE_WORKSPACE="experiments" PROKUBE_API_KEY=<redacted> SANDBOX_POOL="test-pool" SANDBOX_IMAGE="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v08-04-2026" pytest ../pkui/worktrees/integration-sandbox-check/tests/e2e/bench_sandbox.py -k "warm_pool_latencies" -v -s`

## Live Results
- warm pool pause/resume test: resume went from about 6.18s to 2.93s on the current pkui integration deploy
- warm pool benchmark median: `resume (until ready)` about 4.55s
- note: the benchmark also shows a slower first `run_code()` after resume, which should be reviewed before treating this as the final UX fix