### PR TITLE
feat: support sandbox batch file writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ class FileManager:
 
     def write_batch(self, items: list[tuple[str, bytes | str]]) -> BatchFileWriteResponse:
         """Best-effort batch upload with per-file results."""
+
+class BatchFileWriteResponse(BaseModel):
+    success: bool           # True only if every file write succeeded
+    total: int              # Total requested file writes
+    success_count: int      # Number of successful writes
+    failure_count: int      # Number of failed writes
+    results: list[BatchFileWriteResult]
+
+class BatchFileWriteResult(BaseModel):
+    index: int              # Original request position
+    path: str               # Sandbox path for this entry
+    success: bool           # Whether this file write succeeded
+    error: str | None       # Failure detail for best-effort partial failures
      
     def read(self, path: str) -> bytes:
         """Download file from sandbox."""

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ class FileManager:
     def write_batch(self, items: list[tuple[str, bytes | str]]) -> BatchFileWriteResponse:
         """Best-effort batch upload with per-file results."""
 
+    def read(self, path: str) -> bytes:
+        """Download file from sandbox."""
+
+    def list(self, path: str = "/workspace") -> list[FileInfo]:
+        """List files in directory."""
+
+
 class BatchFileWriteResponse(BaseModel):
     success: bool           # True only if every file write succeeded
     total: int              # Total requested file writes
@@ -200,17 +207,12 @@ class BatchFileWriteResponse(BaseModel):
     failure_count: int      # Number of failed writes
     results: list[BatchFileWriteResult]
 
+
 class BatchFileWriteResult(BaseModel):
     index: int              # Original request position
     path: str               # Sandbox path for this entry
     success: bool           # Whether this file write succeeded
     error: str | None       # Failure detail for best-effort partial failures
-     
-    def read(self, path: str) -> bytes:
-        """Download file from sandbox."""
-    
-    def list(self, path: str = "/workspace") -> list[FileInfo]:
-        """List files in directory."""
 ```
 
 ### CodeResult

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ print(result.exit_code)
 
 # File operations
 sbx.files.write("/workspace/data.csv", b"col1,col2\n1,2\n3,4")
+batch_result = sbx.files.write_batch([
+    ("/workspace/app.py", "print('hello')"),
+    ("/workspace/data.bin", b"\x00\x01"),
+])
+assert batch_result.success
 content = sbx.files.read("/workspace/output.txt")
 files = sbx.files.list("/workspace")
 
@@ -184,7 +189,10 @@ class CommandResult(BaseModel):  # Pydantic model
 class FileManager:
     def write(self, path: str, content: bytes | str) -> None:
         """Upload file to sandbox."""
-    
+
+    def write_batch(self, items: list[tuple[str, bytes | str]]) -> BatchFileWriteResponse:
+        """Best-effort batch upload with per-file results."""
+     
     def read(self, path: str) -> bytes:
         """Download file from sandbox."""
     

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -47,6 +47,43 @@ def _parse_status(status_str: str | None, default: SandboxStatus) -> SandboxStat
         return SandboxStatus.UNKNOWN
 
 
+def _parse_batch_file_write_response(
+    response: dict[str, object],
+) -> BatchFileWriteResponse:
+    """Normalize the batch file write response contract."""
+    raw_results = response.get("results", [])
+    if not isinstance(raw_results, list):
+        raise ValueError("Batch file write response must include a results list")
+
+    results = sorted(
+        [item for item in raw_results if isinstance(item, dict)],
+        key=lambda item: item.get("index", 0),
+    )
+    success_count = response.get("successCount", response.get("success_count"))
+    failure_count = response.get("failureCount", response.get("failure_count"))
+
+    if success_count is None:
+        success_count = sum(1 for item in results if item.get("success", False))
+    if failure_count is None:
+        failure_count = len(results) - success_count
+
+    return BatchFileWriteResponse(
+        success=bool(response.get("success", False)),
+        total=int(response.get("total", len(results))),
+        success_count=int(success_count),
+        failure_count=int(failure_count),
+        results=[
+            BatchFileWriteResult(
+                index=item.get("index", 0),
+                path=item.get("path", ""),
+                success=item.get("success", False),
+                error=item.get("error"),
+            )
+            for item in results
+        ],
+    )
+
+
 class SandboxClient:
     """Client for sandbox API operations."""
 
@@ -374,31 +411,7 @@ class SandboxClient:
             self._sandbox_sub_path(name, "files/batch"),
             json=request.model_dump(),
         )
-        raw_results = response.get("results", [])
-        results = sorted(raw_results, key=lambda item: item.get("index", 0))
-        success_count = response.get("successCount", response.get("success_count"))
-        failure_count = response.get("failureCount", response.get("failure_count"))
-
-        if success_count is None:
-            success_count = sum(1 for item in results if item.get("success", False))
-        if failure_count is None:
-            failure_count = len(results) - success_count
-
-        return BatchFileWriteResponse(
-            success=response.get("success", False),
-            total=response.get("total", len(results)),
-            success_count=success_count,
-            failure_count=failure_count,
-            results=[
-                BatchFileWriteResult(
-                    index=item.get("index", 0),
-                    path=item.get("path", ""),
-                    success=item.get("success", False),
-                    error=item.get("error"),
-                )
-                for item in results
-            ],
-        )
+        return _parse_batch_file_write_response(response)
 
     def read_file(self, name: str, path: str) -> bytes:
         """Read a file from sandbox.

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from prokube.common.compat import check_backend_compatibility
@@ -356,10 +357,19 @@ class SandboxClient:
         )
 
     def write_files_batch(
-        self, name: str, items: list[FileWriteRequest]
+        self, name: str, items: Sequence[tuple[str, bytes]]
     ) -> BatchFileWriteResponse:
         """Write multiple files to a sandbox in one request."""
-        request = BatchFileWriteRequest(items=items)
+        request = BatchFileWriteRequest(
+            items=[
+                FileWriteRequest(
+                    path=path,
+                    content=base64.b64encode(content).decode("ascii"),
+                    encoding="base64",
+                )
+                for path, content in items
+            ]
+        )
         response = self._http.post(
             self._sandbox_sub_path(name, "files/batch"),
             json=request.model_dump(),

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -9,6 +9,9 @@ from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import ProKubeError, SandboxError
 from prokube.common.http import HttpClient
 from prokube.sandbox.models import (
+    BatchFileWriteRequest,
+    BatchFileWriteResponse,
+    BatchFileWriteResult,
     ClaimRequest,
     CodeResult,
     CommandResult,
@@ -350,6 +353,36 @@ class SandboxClient:
         self._http.post(
             self._sandbox_sub_path(name, "files"),
             json=request.model_dump(),
+        )
+
+    def write_files_batch(
+        self, name: str, items: list[FileWriteRequest]
+    ) -> BatchFileWriteResponse:
+        """Write multiple files to a sandbox in one request."""
+        request = BatchFileWriteRequest(items=items)
+        response = self._http.post(
+            self._sandbox_sub_path(name, "files/batch"),
+            json=request.model_dump(),
+        )
+        results = response.get("results", [])
+        return BatchFileWriteResponse(
+            success=response.get("success", False),
+            total=response.get("total", len(results)),
+            success_count=response.get(
+                "successCount", response.get("success_count", 0)
+            ),
+            failure_count=response.get(
+                "failureCount", response.get("failure_count", 0)
+            ),
+            results=[
+                BatchFileWriteResult(
+                    index=item.get("index", 0),
+                    path=item.get("path", ""),
+                    success=item.get("success", False),
+                    error=item.get("error"),
+                )
+                for item in results
+            ],
         )
 
     def read_file(self, name: str, path: str) -> bytes:

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -55,10 +55,13 @@ def _parse_batch_file_write_response(
     if not isinstance(raw_results, list):
         raise ValueError("Batch file write response must include a results list")
 
-    results = sorted(
-        [item for item in raw_results if isinstance(item, dict)],
-        key=lambda item: item.get("index", 0),
-    )
+    for index, item in enumerate(raw_results):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Batch file write response item {index} must be an object"
+            )
+
+    results = sorted(raw_results, key=lambda item: item.get("index", 0))
     success_count = response.get("successCount", response.get("success_count"))
     failure_count = response.get("failureCount", response.get("failure_count"))
 
@@ -74,14 +77,35 @@ def _parse_batch_file_write_response(
         failure_count=int(failure_count),
         results=[
             BatchFileWriteResult(
-                index=item.get("index", 0),
-                path=item.get("path", ""),
-                success=item.get("success", False),
+                index=_require_batch_result_int(item, "index"),
+                path=_require_batch_result_str(item, "path"),
+                success=_require_batch_result_bool(item, "success"),
                 error=item.get("error"),
             )
             for item in results
         ],
     )
+
+
+def _require_batch_result_str(item: dict[str, object], field: str) -> str:
+    value = item.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Batch file write response item is missing {field}")
+    return value
+
+
+def _require_batch_result_int(item: dict[str, object], field: str) -> int:
+    value = item.get(field)
+    if not isinstance(value, int):
+        raise ValueError(f"Batch file write response item is missing {field}")
+    return value
+
+
+def _require_batch_result_bool(item: dict[str, object], field: str) -> bool:
+    value = item.get(field)
+    if not isinstance(value, bool):
+        raise ValueError(f"Batch file write response item is missing {field}")
+    return value
 
 
 class SandboxClient:
@@ -407,10 +431,19 @@ class SandboxClient:
                 for path, content in items
             ]
         )
-        response = self._http.post(
-            self._sandbox_sub_path(name, "files/batch"),
-            json=request.model_dump(),
-        )
+        try:
+            response = self._http.post(
+                self._sandbox_sub_path(name, "files/batch"),
+                json=request.model_dump(),
+            )
+        except ProKubeError as e:
+            if e.status_code in (404, 405):
+                raise SandboxError(
+                    "Batch file writes require a backend that supports the "
+                    "sandbox /files/batch endpoint",
+                    status_code=e.status_code,
+                ) from e
+            raise
         return _parse_batch_file_write_response(response)
 
     def read_file(self, name: str, path: str) -> bytes:

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -364,16 +364,21 @@ class SandboxClient:
             self._sandbox_sub_path(name, "files/batch"),
             json=request.model_dump(),
         )
-        results = response.get("results", [])
+        raw_results = response.get("results", [])
+        results = sorted(raw_results, key=lambda item: item.get("index", 0))
+        success_count = response.get("successCount", response.get("success_count"))
+        failure_count = response.get("failureCount", response.get("failure_count"))
+
+        if success_count is None:
+            success_count = sum(1 for item in results if item.get("success", False))
+        if failure_count is None:
+            failure_count = len(results) - success_count
+
         return BatchFileWriteResponse(
             success=response.get("success", False),
             total=response.get("total", len(results)),
-            success_count=response.get(
-                "successCount", response.get("success_count", 0)
-            ),
-            failure_count=response.get(
-                "failureCount", response.get("failure_count", 0)
-            ),
+            success_count=success_count,
+            failure_count=failure_count,
             results=[
                 BatchFileWriteResult(
                     index=item.get("index", 0),

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -79,8 +79,12 @@ def _parse_batch_file_write_response(
     if failure_count is None:
         failure_count = len(results) - success_count
 
+    success = response.get("success")
+    if not isinstance(success, bool):
+        raise ValueError("Batch file write response must include a boolean success")
+
     return BatchFileWriteResponse(
-        success=bool(response.get("success", False)),
+        success=success,
         total=int(response.get("total", len(results))),
         success_count=int(success_count),
         failure_count=int(failure_count),
@@ -97,7 +101,7 @@ def _require_batch_result_str(item: dict[str, object], field: str) -> str:
 
 def _require_batch_result_int(item: dict[str, object], field: str) -> int:
     value = item.get(field)
-    if not isinstance(value, int):
+    if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"Batch file write response item is missing {field}")
     return value
 
@@ -437,8 +441,16 @@ class SandboxClient:
                 self._sandbox_sub_path(name, "files/batch"),
                 json=request.model_dump(),
             )
-        except NotFoundError:
-            raise
+        except NotFoundError as e:
+            try:
+                self.get(name)
+            except NotFoundError:
+                raise
+            raise SandboxError(
+                "Batch file writes require a backend that supports the "
+                "sandbox /files/batch endpoint",
+                status_code=e.status_code,
+            ) from e
         except ProKubeError as e:
             if e.status_code == 405:
                 raise SandboxError(

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from prokube.common.compat import check_backend_compatibility
-from prokube.common.exceptions import ProKubeError, SandboxError
+from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
 from prokube.common.http import HttpClient
 from prokube.sandbox.models import (
     BatchFileWriteRequest,
@@ -51,22 +51,31 @@ def _parse_batch_file_write_response(
     response: dict[str, object],
 ) -> BatchFileWriteResponse:
     """Normalize the batch file write response contract."""
-    raw_results = response.get("results", [])
+    raw_results = response.get("results")
     if not isinstance(raw_results, list):
         raise ValueError("Batch file write response must include a results list")
 
+    results: list[BatchFileWriteResult] = []
     for index, item in enumerate(raw_results):
         if not isinstance(item, dict):
             raise ValueError(
                 f"Batch file write response item {index} must be an object"
             )
+        results.append(
+            BatchFileWriteResult(
+                index=_require_batch_result_int(item, "index"),
+                path=_require_batch_result_str(item, "path"),
+                success=_require_batch_result_bool(item, "success"),
+                error=item.get("error"),
+            )
+        )
 
-    results = sorted(raw_results, key=lambda item: item.get("index", 0))
+    results.sort(key=lambda item: item.index)
     success_count = response.get("successCount", response.get("success_count"))
     failure_count = response.get("failureCount", response.get("failure_count"))
 
     if success_count is None:
-        success_count = sum(1 for item in results if item.get("success", False))
+        success_count = sum(1 for item in results if item.success)
     if failure_count is None:
         failure_count = len(results) - success_count
 
@@ -75,15 +84,7 @@ def _parse_batch_file_write_response(
         total=int(response.get("total", len(results))),
         success_count=int(success_count),
         failure_count=int(failure_count),
-        results=[
-            BatchFileWriteResult(
-                index=_require_batch_result_int(item, "index"),
-                path=_require_batch_result_str(item, "path"),
-                success=_require_batch_result_bool(item, "success"),
-                error=item.get("error"),
-            )
-            for item in results
-        ],
+        results=results,
     )
 
 
@@ -436,8 +437,10 @@ class SandboxClient:
                 self._sandbox_sub_path(name, "files/batch"),
                 json=request.model_dump(),
             )
+        except NotFoundError:
+            raise
         except ProKubeError as e:
-            if e.status_code in (404, 405):
+            if e.status_code == 405:
                 raise SandboxError(
                     "Batch file writes require a backend that supports the "
                     "sandbox /files/batch endpoint",

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -71,6 +71,14 @@ def _parse_batch_file_write_response(
         )
 
     results.sort(key=lambda item: item.index)
+    seen_indexes: set[int] = set()
+    for item in results:
+        if item.index < 0:
+            raise ValueError("Batch file write response index must be non-negative")
+        if item.index in seen_indexes:
+            raise ValueError("Batch file write response indexes must be unique")
+        seen_indexes.add(item.index)
+
     success_count = response.get("successCount", response.get("success_count"))
     failure_count = response.get("failureCount", response.get("failure_count"))
 

--- a/src/prokube/sandbox/files.py
+++ b/src/prokube/sandbox/files.py
@@ -96,6 +96,11 @@ class FileManager:
         Args:
             items: Ordered sequence of ``(path, content)`` pairs. String
                 content is encoded as UTF-8 before upload.
+
+        Returns:
+            A ``BatchFileWriteResponse`` with per-file success/error details.
+            Batch writes are best-effort, so partial failures are reported in
+            the response instead of raising after the request starts.
         """
         if self._check_killed:
             self._check_killed()

--- a/src/prokube/sandbox/files.py
+++ b/src/prokube/sandbox/files.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+import base64
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
-from prokube.sandbox.models import FileInfo
+from prokube.sandbox.models import BatchFileWriteResponse, FileInfo, FileWriteRequest
 
 if TYPE_CHECKING:
     from prokube.sandbox.client import SandboxClient
@@ -81,6 +83,35 @@ class FileManager:
         return self._client.read_file(
             name=self._sandbox_name,
             path=path,
+        )
+
+    def write_batch(
+        self, items: Sequence[tuple[str, bytes | str]]
+    ) -> BatchFileWriteResponse:
+        """Upload multiple files to the sandbox in request order.
+
+        Args:
+            items: Ordered sequence of ``(path, content)`` pairs. String
+                content is encoded as UTF-8 before upload.
+        """
+        if self._check_killed:
+            self._check_killed()
+
+        requests: list[FileWriteRequest] = []
+        for path, content in items:
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            requests.append(
+                FileWriteRequest(
+                    path=path,
+                    content=base64.b64encode(content).decode("ascii"),
+                    encoding="base64",
+                )
+            )
+
+        return self._client.write_files_batch(
+            name=self._sandbox_name,
+            items=requests,
         )
 
     def list(self, path: str = "/workspace") -> list[FileInfo]:

--- a/src/prokube/sandbox/files.py
+++ b/src/prokube/sandbox/files.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
@@ -10,7 +9,6 @@ from prokube.sandbox.models import (
     MAX_BATCH_WRITE_ITEMS,
     BatchFileWriteResponse,
     FileInfo,
-    FileWriteRequest,
 )
 
 if TYPE_CHECKING:
@@ -102,26 +100,23 @@ class FileManager:
         if self._check_killed:
             self._check_killed()
 
+        if not items:
+            raise ValueError("Batch write requires at least 1 item")
+
         if len(items) > MAX_BATCH_WRITE_ITEMS:
             raise ValueError(
                 f"Batch write supports at most {MAX_BATCH_WRITE_ITEMS} items"
             )
 
-        requests: list[FileWriteRequest] = []
+        normalized_items: list[tuple[str, bytes]] = []
         for path, content in items:
             if isinstance(content, str):
                 content = content.encode("utf-8")
-            requests.append(
-                FileWriteRequest(
-                    path=path,
-                    content=base64.b64encode(content).decode("ascii"),
-                    encoding="base64",
-                )
-            )
+            normalized_items.append((path, content))
 
         return self._client.write_files_batch(
             name=self._sandbox_name,
-            items=requests,
+            items=normalized_items,
         )
 
     def list(self, path: str = "/workspace") -> list[FileInfo]:

--- a/src/prokube/sandbox/files.py
+++ b/src/prokube/sandbox/files.py
@@ -6,7 +6,12 @@ import base64
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
-from prokube.sandbox.models import BatchFileWriteResponse, FileInfo, FileWriteRequest
+from prokube.sandbox.models import (
+    MAX_BATCH_WRITE_ITEMS,
+    BatchFileWriteResponse,
+    FileInfo,
+    FileWriteRequest,
+)
 
 if TYPE_CHECKING:
     from prokube.sandbox.client import SandboxClient
@@ -96,6 +101,11 @@ class FileManager:
         """
         if self._check_killed:
             self._check_killed()
+
+        if len(items) > MAX_BATCH_WRITE_ITEMS:
+            raise ValueError(
+                f"Batch write supports at most {MAX_BATCH_WRITE_ITEMS} items"
+            )
 
         requests: list[FileWriteRequest] = []
         for path, content in items:

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -189,14 +189,15 @@ class FileWriteRequest(BaseModel):
     """Request to write a file to sandbox."""
 
     path: str = Field(..., description="Path where to write the file")
-    content: str = Field(..., description="Base64-encoded file content")
+    content: str = Field(
+        ..., description="File content encoded according to the encoding field"
+    )
     encoding: Literal["text", "base64"] = Field(
         default="base64",
         description=(
-            "Content encoding. The SDK always sends base64 because the "
-            "request is JSON and binary content cannot be carried as raw "
-            "bytes. The pkui backend uses this field to decide whether to "
-            "decode the content before forwarding it to execd."
+            "Content encoding. Use 'text' for plain UTF-8 strings or "
+            "'base64' for binary-safe payloads. The SDK's high-level file "
+            "helpers send base64 when uploading bytes."
         ),
     )
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 
 class SandboxStatus(str, Enum):
@@ -239,9 +239,3 @@ class BatchFileWriteResponse(BaseModel):
     results: list[BatchFileWriteResult] = Field(
         default_factory=list, description="Per-file results in request order"
     )
-
-    @model_validator(mode="after")
-    def sort_results_by_index(self) -> BatchFileWriteResponse:
-        """Normalize per-file results back to request order."""
-        self.results = sorted(self.results, key=lambda item: item.index)
-        return self

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -189,7 +190,7 @@ class FileWriteRequest(BaseModel):
 
     path: str = Field(..., description="Path where to write the file")
     content: str = Field(..., description="Base64-encoded file content")
-    encoding: str = Field(
+    encoding: Literal["text", "base64"] = Field(
         default="base64",
         description=(
             "Content encoding. The SDK always sends base64 because the "
@@ -197,4 +198,44 @@ class FileWriteRequest(BaseModel):
             "bytes. The pkui backend uses this field to decide whether to "
             "decode the content before forwarding it to execd."
         ),
+    )
+
+
+MAX_BATCH_WRITE_ITEMS = 100
+
+
+class BatchFileWriteRequest(BaseModel):
+    """Request to write multiple files to a sandbox."""
+
+    items: list[FileWriteRequest] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_BATCH_WRITE_ITEMS,
+        description="Ordered list of file writes to apply",
+    )
+
+
+class BatchFileWriteResult(BaseModel):
+    """Per-file result entry for a batch sandbox upload."""
+
+    index: int = Field(..., description="Zero-based item index in the request")
+    path: str = Field(..., description="File path that was processed")
+    success: bool = Field(..., description="Whether the file write succeeded")
+    error: str | None = Field(
+        default=None,
+        description="Failure detail when the file write did not succeed",
+    )
+
+
+class BatchFileWriteResponse(BaseModel):
+    """Summary response for a batch sandbox upload."""
+
+    success: bool = Field(..., description="True when all requested writes succeeded")
+    total: int = Field(..., description="Total number of file writes requested")
+    success_count: int = Field(
+        ..., description="Number of successful file writes"
+    )
+    failure_count: int = Field(..., description="Number of failed file writes")
+    results: list[BatchFileWriteResult] = Field(
+        default_factory=list, description="Per-file results in request order"
     )

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -197,7 +197,7 @@ class FileWriteRequest(BaseModel):
         description=(
             "Content encoding. Use 'text' for plain UTF-8 strings or "
             "'base64' for binary-safe payloads. The SDK's high-level file "
-            "helpers send base64 when uploading bytes."
+            "helpers send base64 for both text and binary uploads."
         ),
     )
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class SandboxStatus(str, Enum):
@@ -240,10 +240,8 @@ class BatchFileWriteResponse(BaseModel):
         default_factory=list, description="Per-file results in request order"
     )
 
-    @field_validator("results")
-    @classmethod
-    def sort_results_by_index(
-        cls, results: list[BatchFileWriteResult]
-    ) -> list[BatchFileWriteResult]:
+    @model_validator(mode="after")
+    def sort_results_by_index(self) -> BatchFileWriteResponse:
         """Normalize per-file results back to request order."""
-        return sorted(results, key=lambda item: item.index)
+        self.results = sorted(self.results, key=lambda item: item.index)
+        return self

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class SandboxStatus(str, Enum):
@@ -239,3 +239,11 @@ class BatchFileWriteResponse(BaseModel):
     results: list[BatchFileWriteResult] = Field(
         default_factory=list, description="Per-file results in request order"
     )
+
+    @field_validator("results")
+    @classmethod
+    def sort_results_by_index(
+        cls, results: list[BatchFileWriteResult]
+    ) -> list[BatchFileWriteResult]:
+        """Normalize per-file results back to request order."""
+        return sorted(results, key=lambda item: item.index)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,7 @@
 """Tests for Pydantic models."""
 
+import pytest
+
 from prokube.sandbox.client import _parse_batch_file_write_response
 from prokube.sandbox.models import (
     BatchFileWriteResponse,
@@ -251,3 +253,12 @@ class TestBatchFileWriteResponseParsing:
         assert response.success_count == 1
         assert response.failure_count == 1
         assert response.results[1].error == "disk full"
+
+    def test_parse_batch_response_rejects_missing_required_fields(self):
+        with pytest.raises(ValueError, match="missing path"):
+            _parse_batch_file_write_response(
+                {
+                    "success": True,
+                    "results": [{"index": 0, "success": True}],
+                }
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -262,3 +262,12 @@ class TestBatchFileWriteResponseParsing:
                     "results": [{"index": 0, "success": True}],
                 }
             )
+
+    def test_parse_batch_response_rejects_non_object_entries(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_batch_file_write_response(
+                {
+                    "success": True,
+                    "results": ["not-an-object"],
+                }
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -293,3 +293,26 @@ class TestBatchFileWriteResponseParsing:
                     ],
                 }
             )
+
+    def test_parse_batch_response_rejects_negative_index(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            _parse_batch_file_write_response(
+                {
+                    "success": True,
+                    "results": [
+                        {"index": -1, "path": "/workspace/a.txt", "success": True}
+                    ],
+                }
+            )
+
+    def test_parse_batch_response_rejects_duplicate_indexes(self):
+        with pytest.raises(ValueError, match="unique"):
+            _parse_batch_file_write_response(
+                {
+                    "success": True,
+                    "results": [
+                        {"index": 0, "path": "/workspace/a.txt", "success": True},
+                        {"index": 0, "path": "/workspace/b.txt", "success": False},
+                    ],
+                }
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -271,3 +271,25 @@ class TestBatchFileWriteResponseParsing:
                     "results": ["not-an-object"],
                 }
             )
+
+    def test_parse_batch_response_rejects_non_boolean_success(self):
+        with pytest.raises(ValueError, match="boolean success"):
+            _parse_batch_file_write_response(
+                {
+                    "success": "false",
+                    "results": [
+                        {"index": 0, "path": "/workspace/a.txt", "success": True}
+                    ],
+                }
+            )
+
+    def test_parse_batch_response_rejects_boolean_index(self):
+        with pytest.raises(ValueError, match="missing index"):
+            _parse_batch_file_write_response(
+                {
+                    "success": True,
+                    "results": [
+                        {"index": True, "path": "/workspace/a.txt", "success": True}
+                    ],
+                }
+            )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,8 @@
 """Tests for Pydantic models."""
 
+from prokube.sandbox.client import _parse_batch_file_write_response
 from prokube.sandbox.models import (
+    BatchFileWriteResponse,
     ClaimRequest,
     CodeResult,
     CommandResult,
@@ -186,3 +188,66 @@ class TestRequestModels:
         # to disk (issue #18).
         assert req.encoding == "base64"
         assert req.model_dump()["encoding"] == "base64"
+
+    def test_batch_file_write_response_preserves_result_fields(self):
+        """Batch response model keeps the per-file payload intact."""
+        response = BatchFileWriteResponse(
+            success=False,
+            total=2,
+            success_count=1,
+            failure_count=1,
+            results=[
+                {"index": 1, "path": "/workspace/b.txt", "success": False},
+                {"index": 0, "path": "/workspace/a.txt", "success": True},
+            ],
+        )
+
+        assert [item.index for item in response.results] == [1, 0]
+        assert response.results[1].path == "/workspace/a.txt"
+
+
+class TestBatchFileWriteResponseParsing:
+    """Tests for batch write response normalization helpers."""
+
+    def test_parse_batch_response_sorts_results_by_index(self):
+        response = _parse_batch_file_write_response(
+            {
+                "success": True,
+                "total": 2,
+                "results": [
+                    {"index": 1, "path": "/workspace/b.txt", "success": True},
+                    {"index": 0, "path": "/workspace/a.txt", "success": True},
+                ],
+            }
+        )
+
+        assert [item.index for item in response.results] == [0, 1]
+        assert [item.path for item in response.results] == [
+            "/workspace/a.txt",
+            "/workspace/b.txt",
+        ]
+        assert response.success_count == 2
+        assert response.failure_count == 0
+
+    def test_parse_batch_response_supports_legacy_counts(self):
+        response = _parse_batch_file_write_response(
+            {
+                "success": False,
+                "total": 2,
+                "success_count": 1,
+                "failure_count": 1,
+                "results": [
+                    {"index": 0, "path": "/workspace/a.txt", "success": True},
+                    {
+                        "index": 1,
+                        "path": "/workspace/b.txt",
+                        "success": False,
+                        "error": "disk full",
+                    },
+                ],
+            }
+        )
+
+        assert response.success_count == 1
+        assert response.failure_count == 1
+        assert response.results[1].error == "disk full"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,6 +1,11 @@
 """Tests for Sandbox class."""
 
 import base64
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -680,6 +685,60 @@ class TestSandboxFiles:
 
         sbx._client.close()
 
+    def test_write_batch_files_sorts_results_by_index(self):
+        """Returned results are normalized back to request order by index."""
+        script = textwrap.dedent(
+            """
+            from prokube.common.config import Config
+            from prokube.sandbox.client import SandboxClient
+            from prokube.sandbox.models import FileWriteRequest
+
+            client = SandboxClient(
+                Config(
+                    api_url="https://test.example.com",
+                    workspace="test-ws",
+                    user_id="test-user@example.com",
+                ),
+                check_version=False,
+            )
+            client._http.post = lambda *args, **kwargs: {
+                "success": True,
+                "total": 2,
+                "results": [
+                    {"index": 1, "path": "/workspace/beta.txt", "success": True},
+                    {"index": 0, "path": "/workspace/alpha.txt", "success": True},
+                ],
+            }
+
+            result = client.write_files_batch(
+                "sandbox-test",
+                [FileWriteRequest(path="/workspace/alpha.txt", content="YWxwaGE=")],
+            )
+            print([item.index for item in result.results])
+            print([item.path for item in result.results])
+            print(result.success_count)
+            print(result.failure_count)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={
+                **os.environ,
+                "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+            },
+        )
+
+        output = result.stdout.strip().splitlines()
+        assert output == [
+            "[0, 1]",
+            "['/workspace/alpha.txt', '/workspace/beta.txt']",
+            "2",
+            "0",
+        ]
+
     def test_write_batch_files_rejects_empty_batches(self, mock_env, httpx_mock: HTTPXMock):
         """Empty batches are rejected client-side before any file request."""
         httpx_mock.add_response(
@@ -697,6 +756,33 @@ class TestSandboxFiles:
 
         with pytest.raises(ValidationError):
             sbx.files.write_batch([])
+
+        requests = httpx_mock.get_requests()
+        assert all("files/batch" not in str(request.url) for request in requests)
+
+        sbx._client.close()
+
+    def test_write_batch_files_rejects_too_many_items(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Oversized batches are rejected before content is encoded or sent."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+
+        with pytest.raises(ValueError, match="at most 100 items"):
+            sbx.files.write_batch(
+                [(f"/workspace/file-{idx}.txt", "x") for idx in range(101)]
+            )
 
         requests = httpx_mock.get_requests()
         assert all("files/batch" not in str(request.url) for request in requests)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -3,7 +3,6 @@
 import base64
 
 import pytest
-from pydantic import ValidationError
 from pytest_httpx import HTTPXMock
 
 from prokube.sandbox import Sandbox
@@ -695,7 +694,7 @@ class TestSandboxFiles:
 
         sbx = Sandbox.from_pool("python-pool")
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError, match="at least 1 item"):
             sbx.files.write_batch([])
 
         requests = httpx_mock.get_requests()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,6 +5,7 @@ import base64
 import pytest
 from pytest_httpx import HTTPXMock
 
+from prokube.common.exceptions import SandboxError
 from prokube.sandbox import Sandbox
 
 
@@ -676,6 +677,32 @@ class TestSandboxFiles:
         assert result.success is False
         assert result.failure_count == 1
         assert result.results[1].error == "Sandbox is not running"
+
+        sbx._client.close()
+
+    def test_write_batch_files_unsupported_backend(self, mock_env, httpx_mock: HTTPXMock):
+        """Older backends surface a clear error for missing batch route."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            status_code=404,
+            json={"detail": "Not Found"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+
+        with pytest.raises(SandboxError, match="require a backend"):
+            sbx.files.write_batch([("/workspace/alpha.txt", "alpha")])
 
         sbx._client.close()
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,6 +1,9 @@
 """Tests for Sandbox class."""
 
+import base64
+
 import pytest
+from pydantic import ValidationError
 from pytest_httpx import HTTPXMock
 
 from prokube.sandbox import Sandbox
@@ -508,6 +511,195 @@ class TestSandboxFiles:
         assert body["encoding"] == "base64"
         assert body["content"] == base64.b64encode(b"hello world").decode("ascii")
         assert body["path"] == "/workspace/test.txt"
+
+        sbx._client.close()
+
+    def test_write_batch_files(self, mock_env, httpx_mock: HTTPXMock):
+        """Test writing multiple files with one batch request."""
+        import json
+
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            json={
+                "success": True,
+                "total": 2,
+                "successCount": 2,
+                "failureCount": 0,
+                "results": [
+                    {
+                        "index": 0,
+                        "path": "/workspace/alpha.txt",
+                        "success": True,
+                    },
+                    {
+                        "index": 1,
+                        "path": "/workspace/beta.bin",
+                        "success": True,
+                    },
+                ],
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.files.write_batch(
+            [
+                ("/workspace/alpha.txt", "alpha"),
+                ("/workspace/beta.bin", b"\x00\xff"),
+            ]
+        )
+
+        assert result.success is True
+        assert result.success_count == 2
+        assert result.failure_count == 0
+        assert [item.path for item in result.results] == [
+            "/workspace/alpha.txt",
+            "/workspace/beta.bin",
+        ]
+
+        requests = httpx_mock.get_requests()
+        file_request = requests[-1]
+        assert "/files/batch" in str(file_request.url)
+
+        body = json.loads(file_request.content)
+        assert len(body["items"]) == 2
+        assert body["items"][0] == {
+            "path": "/workspace/alpha.txt",
+            "content": base64.b64encode(b"alpha").decode("ascii"),
+            "encoding": "base64",
+        }
+        assert body["items"][1] == {
+            "path": "/workspace/beta.bin",
+            "content": base64.b64encode(b"\x00\xff").decode("ascii"),
+            "encoding": "base64",
+        }
+
+        sbx._client.close()
+
+    def test_write_batch_files_external_api_key_path(
+        self, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Batch writes use the external sandbox route for API-key auth."""
+        monkeypatch.setenv("PROKUBE_API_URL", "https://test.example.com")
+        monkeypatch.setenv("PROKUBE_WORKSPACE", "test-ws")
+        monkeypatch.delenv("PROKUBE_USER_ID", raising=False)
+        monkeypatch.setenv("PROKUBE_API_KEY", "secret-key")
+
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/sandbox/test-ws/sandboxes/sandbox-test/files/batch",
+            json={
+                "success": True,
+                "total": 1,
+                "successCount": 1,
+                "failureCount": 0,
+                "results": [
+                    {
+                        "index": 0,
+                        "path": "/workspace/alpha.txt",
+                        "success": True,
+                    }
+                ],
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.files.write_batch([("/workspace/alpha.txt", "alpha")])
+
+        assert result.success is True
+        requests = httpx_mock.get_requests()
+        assert str(requests[-1].url) == (
+            "https://test.example.com/sandbox/test-ws/"
+            "sandboxes/sandbox-test/files/batch"
+        )
+
+        sbx._client.close()
+
+    def test_write_batch_files_partial_failure(self, mock_env, httpx_mock: HTTPXMock):
+        """Partial failure responses preserve per-file error details."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            json={
+                "success": False,
+                "total": 2,
+                "successCount": 1,
+                "failureCount": 1,
+                "results": [
+                    {
+                        "index": 0,
+                        "path": "/workspace/alpha.txt",
+                        "success": True,
+                    },
+                    {
+                        "index": 1,
+                        "path": "/workspace/beta.txt",
+                        "success": False,
+                        "error": "Sandbox is not running",
+                    },
+                ],
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.files.write_batch(
+            [
+                ("/workspace/alpha.txt", "alpha"),
+                ("/workspace/beta.txt", "beta"),
+            ]
+        )
+
+        assert result.success is False
+        assert result.failure_count == 1
+        assert result.results[1].error == "Sandbox is not running"
+
+        sbx._client.close()
+
+    def test_write_batch_files_rejects_empty_batches(self, mock_env, httpx_mock: HTTPXMock):
+        """Empty batches are rejected client-side before any file request."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+
+        with pytest.raises(ValidationError):
+            sbx.files.write_batch([])
+
+        requests = httpx_mock.get_requests()
+        assert all("files/batch" not in str(request.url) for request in requests)
 
         sbx._client.close()
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,11 +1,6 @@
 """Tests for Sandbox class."""
 
 import base64
-import os
-import subprocess
-import sys
-import textwrap
-from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -684,60 +679,6 @@ class TestSandboxFiles:
         assert result.results[1].error == "Sandbox is not running"
 
         sbx._client.close()
-
-    def test_write_batch_files_sorts_results_by_index(self):
-        """Returned results are normalized back to request order by index."""
-        script = textwrap.dedent(
-            """
-            from prokube.common.config import Config
-            from prokube.sandbox.client import SandboxClient
-            from prokube.sandbox.models import FileWriteRequest
-
-            client = SandboxClient(
-                Config(
-                    api_url="https://test.example.com",
-                    workspace="test-ws",
-                    user_id="test-user@example.com",
-                ),
-                check_version=False,
-            )
-            client._http.post = lambda *args, **kwargs: {
-                "success": True,
-                "total": 2,
-                "results": [
-                    {"index": 1, "path": "/workspace/beta.txt", "success": True},
-                    {"index": 0, "path": "/workspace/alpha.txt", "success": True},
-                ],
-            }
-
-            result = client.write_files_batch(
-                "sandbox-test",
-                [FileWriteRequest(path="/workspace/alpha.txt", content="YWxwaGE=")],
-            )
-            print([item.index for item in result.results])
-            print([item.path for item in result.results])
-            print(result.success_count)
-            print(result.failure_count)
-            """
-        )
-        result = subprocess.run(
-            [sys.executable, "-c", script],
-            capture_output=True,
-            text=True,
-            check=True,
-            env={
-                **os.environ,
-                "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
-            },
-        )
-
-        output = result.stdout.strip().splitlines()
-        assert output == [
-            "[0, 1]",
-            "['/workspace/alpha.txt', '/workspace/beta.txt']",
-            "2",
-            "0",
-        ]
 
     def test_write_batch_files_rejects_empty_batches(self, mock_env, httpx_mock: HTTPXMock):
         """Empty batches are rejected client-side before any file request."""

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -695,8 +695,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
-            status_code=405,
-            json={"detail": "Method Not Allowed"},
+            status_code=404,
+            json={"detail": "Not Found"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "status": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -695,8 +695,8 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
-            status_code=404,
-            json={"detail": "Not Found"},
+            status_code=405,
+            json={"detail": "Method Not Allowed"},
         )
 
         sbx = Sandbox.from_pool("python-pool")


### PR DESCRIPTION
## Summary
- add Python SDK support for the sandbox batch file write endpoint introduced in pkui PR 1882
- expose a high-level `write_batch` API and map best-effort per-file results for callers
- cover internal and external routing, partial failures, and batch validation in tests

## Testing
- `uv run pytest tests/test_sandbox.py -q`
- `uv run ruff check src/prokube/sandbox/models.py src/prokube/sandbox/client.py src/prokube/sandbox/files.py tests/test_sandbox.py`

Closes #28