### PR TITLE
fix: reset stale warmup kernel sessions

### DIFF
--- a/src/prokube/sandbox/code.py
+++ b/src/prokube/sandbox/code.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from prokube.sandbox.models import CodeResult
 

--- a/src/prokube/sandbox/code.py
+++ b/src/prokube/sandbox/code.py
@@ -110,6 +110,7 @@ class CodeRunner:
         The next run_code() call will restart the kernel and clear all
         variables and imports from previous executions.
         """
+        self._session_id = None
         self._reset_on_next_exec = True
 
     @property

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -269,8 +269,10 @@ class Sandbox:
         Notes:
             * The marker is per-call (``uuid4().hex``) to avoid collisions
               with any user code that happens to print a similar literal.
-            * The probe must NOT pass ``reset_session=True`` or an explicit
-              ``session_id``; it exercises the same code path the user will.
+            * If a probe returns successfully but without the marker, discard
+              that session before retrying. Otherwise a cold/stale Jupyter
+              session can be reused forever and every probe keeps returning
+              empty stdout.
 
         Args:
             deadline: ``time.monotonic()`` value after which the probe gives
@@ -307,6 +309,7 @@ class Sandbox:
             result = self.run_code(code, timeout=probe_timeout)
             if result.stdout.strip() == marker:
                 return
+            self._code.reset_session()
             # Loop top will recompute remaining and exit if deadline passed.
             sleep_for = min(0.5, max(0.0, deadline - time.monotonic()))
             time.sleep(sleep_for)

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -353,6 +353,10 @@ class TestWaitUntilReady:
 
         def _probe_callback(request: httpx.Request) -> httpx.Response:
             call_counter["n"] += 1
+            body = json.loads(request.content)
+            if call_counter["n"] > 1:
+                assert "session_id" not in body
+                assert body.get("reset_session") is True
             marker = _extract_marker(request) or ""
             if call_counter["n"] == 1:
                 return httpx.Response(

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -404,9 +404,9 @@ class TestSandboxRunCode:
         sbx.run_code("x = 42")
         assert sbx.session_id == "session-abc123"
 
-        # Reset session - sets flag for next exec, session_id stays until then
+        # Reset session - clears stale client-side session and sets flag for next exec
         sbx.reset_session()
-        assert sbx.session_id == "session-abc123"
+        assert sbx.session_id is None
 
         # Next run_code should include reset_session=true in request
         sbx.run_code("y = 1")
@@ -420,6 +420,7 @@ class TestSandboxRunCode:
 
         second_body = json.loads(second_exec_body)
         assert second_body.get("reset_session") is True
+        assert "session_id" not in second_body
 
         # After successful call, flag should be cleared
         assert sbx.session_id == "session-new456"


### PR DESCRIPTION
## Summary
- Clear stale Jupyter session IDs before warmup retry probes.
- Send reset_session on retry so cold/stale kernels do not keep returning empty stdout.

## Testing
- uv run --extra dev pytest tests/test_pause_resume.py -q