### PR TITLE
fix: report sandbox execution timeouts as failures

### DIFF
--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -119,6 +120,36 @@ def _require_batch_result_bool(item: dict[str, object], field: str) -> bool:
     if not isinstance(value, bool):
         raise ValueError(f"Batch file write response item is missing {field}")
     return value
+
+
+def _is_timeout_execution_response(response: dict[str, object]) -> bool:
+    error_names = (response.get("error_name"), response.get("errorName"))
+    if any(
+        isinstance(value, str) and re.search(r"timeout", value, re.I)
+        for value in error_names
+    ):
+        return True
+
+    structured_values = (
+        response.get("error_value"),
+        response.get("errorValue"),
+        response.get("detail"),
+    )
+    if any(
+        isinstance(value, str) and re.search(r"\btime(?:d)?\s*out\b", value, re.I)
+        for value in structured_values
+    ):
+        return True
+
+    stderr = response.get("stderr")
+    return isinstance(stderr, str) and _is_timeout_stderr(stderr)
+
+
+def _is_timeout_stderr(value: str) -> bool:
+    return bool(
+        re.search(r"^\s*\[?timeout\b", value, re.I)
+        or re.search(r"\b(?:execution|command|code)\s+timed\s+out\b", value, re.I)
+    )
 
 
 class SandboxClient:
@@ -364,15 +395,16 @@ class SandboxClient:
             self._sandbox_sub_path(name, "exec"),
             json=request.model_dump(exclude_none=True),
         )
+        timed_out = _is_timeout_execution_response(response)
         return CodeResult(
             stdout=response.get("stdout", ""),
             stderr=response.get("stderr", ""),
-            success=response.get("success", False),
+            success=response.get("success", False) and not timed_out,
             execution_time_ms=response.get(
                 "durationMs", response.get("execution_time_ms", 0)
             ),
-            error_name=response.get("error_name"),
-            error_value=response.get("error_value"),
+            error_name=response.get("errorName", response.get("error_name")),
+            error_value=response.get("errorValue", response.get("error_value")),
             traceback=response.get("traceback"),
             session_id=response.get("session_id"),
         )
@@ -406,10 +438,12 @@ class SandboxClient:
                 exclude={"language", "session_id", "reset_session"}
             ),
         )
+        timed_out = _is_timeout_execution_response(response)
+        exit_code = response.get("exitCode", response.get("exit_code", -1))
         return CommandResult(
             stdout=response.get("stdout", ""),
             stderr=response.get("stderr", ""),
-            exit_code=response.get("exitCode", response.get("exit_code", -1)),
+            exit_code=-1 if timed_out else exit_code,
             duration_ms=response.get("durationMs", response.get("duration_ms", 0)),
         )
 

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -147,7 +147,7 @@ def _is_timeout_execution_response(response: dict[str, object]) -> bool:
 
 def _is_timeout_stderr(value: str) -> bool:
     return bool(
-        re.search(r"^\s*\[?timeout\b", value, re.I)
+        re.search(r"^\s*(?:\[timeout:|timeout:)", value, re.I)
         or re.search(r"\b(?:execution|command|code)\s+timed\s+out\b", value, re.I)
     )
 
@@ -403,8 +403,8 @@ class SandboxClient:
             execution_time_ms=response.get(
                 "durationMs", response.get("execution_time_ms", 0)
             ),
-            error_name=response.get("errorName", response.get("error_name")),
-            error_value=response.get("errorValue", response.get("error_value")),
+            error_name=response.get("errorName") or response.get("error_name"),
+            error_value=response.get("errorValue") or response.get("error_value"),
             traceback=response.get("traceback"),
             session_id=response.get("session_id"),
         )

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -298,6 +298,75 @@ class TestSandboxRunCode:
 
         sbx._client.close()
 
+    def test_run_code_timeout_stderr_maps_to_failure(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Timeout-shaped code responses are failures even with success=true."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "",
+                "stderr": "Execution timed out after 5 seconds",
+                "success": True,
+                "durationMs": 5000,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.run_code("while True: pass")
+
+        assert result.success is False
+        assert "timed out" in result.stderr
+        assert result.execution_time_ms == 5000
+
+        sbx._client.close()
+
+    def test_run_code_timeout_error_name_maps_to_failure(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Structured timeout fields make code execution unsuccessful."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "",
+                "stderr": "",
+                "success": True,
+                "errorName": "TimeoutError",
+                "errorValue": "Code execution timed out",
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.run_code("while True: pass")
+
+        assert result.success is False
+        assert result.error_name == "TimeoutError"
+        assert result.error_value == "Code execution timed out"
+
+        sbx._client.close()
+
     def test_run_code_maintains_session(self, mock_env, httpx_mock: HTTPXMock):
         """Test that session_id is maintained across run_code calls."""
         # Mock version check
@@ -465,6 +534,108 @@ class TestSandboxCommands:
         assert result.stdout == "file1.txt\nfile2.txt\n"
         assert result.exit_code == 0
         assert result.success is True
+
+        sbx._client.close()
+
+    def test_run_command_timeout_maps_to_non_zero_exit(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Timeout-shaped command responses are not successful exit 0 results."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "",
+                "stderr": "[Timeout: no response after 15s]",
+                "exitCode": 0,
+                "durationMs": 15000,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.commands.run("sleep 30")
+
+        assert result.exit_code == -1
+        assert result.success is False
+        assert result.stderr == "[Timeout: no response after 15s]"
+
+        sbx._client.close()
+
+    def test_run_command_timeout_error_name_maps_to_non_zero_exit(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Structured timeout fields make command execution unsuccessful."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "",
+                "stderr": "",
+                "errorName": "ExecutionTimeout",
+                "exitCode": 0,
+                "durationMs": 15000,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.commands.run("sleep 30")
+
+        assert result.exit_code == -1
+        assert result.success is False
+
+        sbx._client.close()
+
+    def test_run_command_ordinary_stderr_timeout_text_stays_success(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Ordinary stderr mentioning timeout is not treated as a timeout result."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "ok\n",
+                "stderr": "warning: timeout option ignored\n",
+                "exitCode": 0,
+                "durationMs": 10,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.commands.run("tool --timeout 5")
+
+        assert result.exit_code == 0
+        assert result.success is True
+        assert result.stderr == "warning: timeout option ignored\n"
 
         sbx._client.close()
 
@@ -680,7 +851,9 @@ class TestSandboxFiles:
 
         sbx._client.close()
 
-    def test_write_batch_files_unsupported_backend(self, mock_env, httpx_mock: HTTPXMock):
+    def test_write_batch_files_unsupported_backend(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
         """Older backends surface a clear error for missing batch route."""
         httpx_mock.add_response(
             method="GET",
@@ -711,7 +884,9 @@ class TestSandboxFiles:
 
         sbx._client.close()
 
-    def test_write_batch_files_rejects_empty_batches(self, mock_env, httpx_mock: HTTPXMock):
+    def test_write_batch_files_rejects_empty_batches(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
         """Empty batches are rejected client-side before any file request."""
         httpx_mock.add_response(
             method="GET",

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -367,6 +367,42 @@ class TestSandboxRunCode:
 
         sbx._client.close()
 
+    def test_run_code_empty_camel_error_fields_fall_back_to_snake_case(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Empty camelCase error fields do not hide populated snake_case fields."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "",
+                "stderr": "",
+                "success": False,
+                "errorName": "",
+                "error_name": "ValueError",
+                "errorValue": None,
+                "error_value": "invalid value",
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.run_code("raise ValueError('invalid value')")
+
+        assert result.error_name == "ValueError"
+        assert result.error_value == "invalid value"
+
+        sbx._client.close()
+
     def test_run_code_maintains_session(self, mock_env, httpx_mock: HTTPXMock):
         """Test that session_id is maintained across run_code calls."""
         # Mock version check
@@ -636,6 +672,40 @@ class TestSandboxCommands:
         assert result.exit_code == 0
         assert result.success is True
         assert result.stderr == "warning: timeout option ignored\n"
+
+        sbx._client.close()
+
+    def test_run_command_stderr_starting_with_timeout_word_stays_success(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Only backend timeout banners at stderr start are treated as timeouts."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            json={
+                "stdout": "ok\n",
+                "stderr": "timeout option ignored\n",
+                "exitCode": 0,
+                "durationMs": 10,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        result = sbx.commands.run("tool --timeout 5")
+
+        assert result.exit_code == 0
+        assert result.success is True
+        assert result.stderr == "timeout option ignored\n"
 
         sbx._client.close()
 


### PR DESCRIPTION
## Summary
- Mirror TypeScript SDK PR #28 timeout parsing behavior in the Python SDK
- Treat timeout-shaped code execution responses as failed even when backend returns success=true
- Treat timeout-shaped command responses as non-zero exit results while preserving backend-provided stderr
- Avoid false positives for ordinary stderr text that merely mentions timeout options

Parity reference: https://github.com/prokube/prokube-sdk-ts/pull/28

## Testing
- uv run --extra dev pytest tests/test_sandbox.py -v
- uv run --extra dev ruff check src/prokube/sandbox/client.py tests/test_sandbox.py