### PR TITLE
feat: support sandbox auto-idle timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prokube-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for prokube.ai platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prokube/_version.py
+++ b/src/prokube/_version.py
@@ -1,3 +1,3 @@
 """Version information for prokube-sdk."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -10,20 +10,12 @@ from typing import TYPE_CHECKING
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
 from prokube.common.http import HttpClient
-from prokube.sandbox.models import (
-    BatchFileWriteRequest,
-    BatchFileWriteResponse,
-    BatchFileWriteResult,
-    ClaimRequest,
-    CodeResult,
-    CommandResult,
-    CreateRequest,
-    ExecRequest,
-    FileInfo,
-    FileWriteRequest,
-    SandboxInfo,
-    SandboxStatus,
-)
+from prokube.sandbox.models import (BatchFileWriteRequest,
+                                    BatchFileWriteResponse,
+                                    BatchFileWriteResult, ClaimRequest,
+                                    CodeResult, CommandResult, CreateRequest,
+                                    ExecRequest, FileInfo, FileWriteRequest,
+                                    SandboxInfo, SandboxStatus)
 
 if TYPE_CHECKING:
     from prokube.common.config import Config
@@ -46,6 +38,13 @@ def _parse_status(status_str: str | None, default: SandboxStatus) -> SandboxStat
         return SandboxStatus(status_str)
     except ValueError:
         return SandboxStatus.UNKNOWN
+
+
+def _auto_idle_timeout(response: dict[str, object]) -> int | None:
+    value = response.get(
+        "autoIdleTimeoutSeconds", response.get("auto_idle_timeout_seconds")
+    )
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _parse_batch_file_write_response(
@@ -191,27 +190,39 @@ class SandboxClient:
         """
         return f"{self._sandbox_path(name)}/{sub}"
 
-    def claim_from_pool(self, pool: str) -> SandboxInfo:
+    def claim_from_pool(
+        self, pool: str, auto_idle_timeout_seconds: int | None = None
+    ) -> SandboxInfo:
         """Claim a sandbox from a warm pool.
 
         Args:
             pool: Name of the warm pool.
+            auto_idle_timeout_seconds: Per-claim auto-idle override in seconds.
 
         Returns:
             Information about the claimed sandbox.
         """
-        request = ClaimRequest(pool_name=pool)
+        request = ClaimRequest(
+            pool_name=pool,
+            auto_idle_timeout_seconds=auto_idle_timeout_seconds,
+        )
         response = self._http.post(
             f"{self._sandboxes_path()}/claim",
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
         # API returns sandboxName for claim endpoint
         sandbox_name = response.get("sandboxName") or response["name"]
+        response_auto_idle_timeout = _auto_idle_timeout(response)
         return SandboxInfo(
             name=sandbox_name,
             workspace=self.config.workspace,
             status=_parse_status(response.get("status"), SandboxStatus.RUNNING),
             pool=pool,
+            auto_idle_timeout_seconds=(
+                response_auto_idle_timeout
+                if response_auto_idle_timeout is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     def create(
@@ -221,6 +232,7 @@ class SandboxClient:
         cpu: str | None = None,
         memory: str | None = None,
         allow_internet_access: bool | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
     ) -> SandboxInfo:
@@ -234,6 +246,7 @@ class SandboxClient:
                 if None.
             allow_internet_access: Whether the sandbox may reach the public
                 internet. Backend default used if None.
+            auto_idle_timeout_seconds: Per-sandbox auto-idle override in seconds.
             env_vars: Environment variables to inject into the sandbox. Each
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into the sandbox.
@@ -253,6 +266,7 @@ class SandboxClient:
             cpu=cpu,
             memory=memory,
             allow_internet_access=allow_internet_access,
+            auto_idle_timeout_seconds=auto_idle_timeout_seconds,
             env_vars=env_vars,
             secret_refs=secret_refs,
         )
@@ -262,11 +276,17 @@ class SandboxClient:
         )
         # API returns 'phase' instead of 'status' for sandbox phase
         status_str = response.get("status") or response.get("phase")
+        response_auto_idle_timeout = _auto_idle_timeout(response)
         return SandboxInfo(
             name=response["name"],
             workspace=self.config.workspace,
             status=_parse_status(status_str, SandboxStatus.PENDING),
             image=image,
+            auto_idle_timeout_seconds=(
+                response_auto_idle_timeout
+                if response_auto_idle_timeout is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     def list(self) -> list[SandboxInfo]:
@@ -289,6 +309,7 @@ class SandboxClient:
                 image=s.get("image") or None,
                 pool=s.get("poolName") or s.get("pool"),
                 created_at=s.get("createdAt") or s.get("created_at"),
+                auto_idle_timeout_seconds=_auto_idle_timeout(s),
             )
             for s in sandboxes
         ]
@@ -313,6 +334,7 @@ class SandboxClient:
             image=response.get("image"),
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),
+            auto_idle_timeout_seconds=_auto_idle_timeout(response),
         )
 
     def pause(self, name: str) -> None:
@@ -362,6 +384,7 @@ class SandboxClient:
             image=response.get("image"),
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),
+            auto_idle_timeout_seconds=_auto_idle_timeout(response),
             resumed_from_pool=response.get("resumedFromPool", False),
         )
 

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -10,12 +10,21 @@ from typing import TYPE_CHECKING
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
 from prokube.common.http import HttpClient
-from prokube.sandbox.models import (BatchFileWriteRequest,
-                                    BatchFileWriteResponse,
-                                    BatchFileWriteResult, ClaimRequest,
-                                    CodeResult, CommandResult, CreateRequest,
-                                    ExecRequest, FileInfo, FileWriteRequest,
-                                    SandboxInfo, SandboxStatus)
+from prokube.sandbox.models import (
+    BatchFileWriteRequest,
+    BatchFileWriteResponse,
+    BatchFileWriteResult,
+    ClaimRequest,
+    CodeResult,
+    CommandResult,
+    CreateRequest,
+    ExecRequest,
+    FileInfo,
+    FileWriteRequest,
+    SandboxInfo,
+    SandboxStatus,
+    parse_auto_idle_timeout,
+)
 
 if TYPE_CHECKING:
     from prokube.common.config import Config
@@ -38,13 +47,6 @@ def _parse_status(status_str: str | None, default: SandboxStatus) -> SandboxStat
         return SandboxStatus(status_str)
     except ValueError:
         return SandboxStatus.UNKNOWN
-
-
-def _auto_idle_timeout(response: dict[str, object]) -> int | None:
-    value = response.get(
-        "autoIdleTimeoutSeconds", response.get("auto_idle_timeout_seconds")
-    )
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def _parse_batch_file_write_response(
@@ -212,7 +214,7 @@ class SandboxClient:
         )
         # API returns sandboxName for claim endpoint
         sandbox_name = response.get("sandboxName") or response["name"]
-        response_auto_idle_timeout = _auto_idle_timeout(response)
+        response_auto_idle_timeout = parse_auto_idle_timeout(response)
         return SandboxInfo(
             name=sandbox_name,
             workspace=self.config.workspace,
@@ -276,7 +278,7 @@ class SandboxClient:
         )
         # API returns 'phase' instead of 'status' for sandbox phase
         status_str = response.get("status") or response.get("phase")
-        response_auto_idle_timeout = _auto_idle_timeout(response)
+        response_auto_idle_timeout = parse_auto_idle_timeout(response)
         return SandboxInfo(
             name=response["name"],
             workspace=self.config.workspace,
@@ -309,7 +311,7 @@ class SandboxClient:
                 image=s.get("image") or None,
                 pool=s.get("poolName") or s.get("pool"),
                 created_at=s.get("createdAt") or s.get("created_at"),
-                auto_idle_timeout_seconds=_auto_idle_timeout(s),
+                auto_idle_timeout_seconds=parse_auto_idle_timeout(s),
             )
             for s in sandboxes
         ]
@@ -334,7 +336,7 @@ class SandboxClient:
             image=response.get("image"),
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),
-            auto_idle_timeout_seconds=_auto_idle_timeout(response),
+            auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
         )
 
     def pause(self, name: str) -> None:
@@ -384,7 +386,7 @@ class SandboxClient:
             image=response.get("image"),
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),
-            auto_idle_timeout_seconds=_auto_idle_timeout(response),
+            auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
             resumed_from_pool=response.get("resumedFromPool", False),
         )
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -31,6 +31,10 @@ class SandboxInfo(BaseModel):
     image: str | None = Field(default=None, description="Container image")
     pool: str | None = Field(default=None, description="WarmPool name if claimed")
     created_at: str | None = Field(default=None, description="Creation timestamp")
+    auto_idle_timeout_seconds: int | None = Field(
+        default=None,
+        description="Auto-idle timeout override in seconds, when configured",
+    )
     resumed_from_pool: bool = Field(
         default=False,
         description="True when a resume response came from a warm-pool swap",
@@ -115,6 +119,11 @@ class ClaimRequest(BaseModel):
     pool_name: str = Field(
         ..., serialization_alias="poolName", description="Name of the warm pool"
     )
+    auto_idle_timeout_seconds: int | None = Field(
+        default=None,
+        serialization_alias="autoIdleTimeoutSeconds",
+        description="Per-claim auto-idle override in seconds",
+    )
 
 
 class EnvVar(BaseModel):
@@ -138,6 +147,11 @@ class CreateRequest(BaseModel):
         serialization_alias="allowInternetAccess",
         description="Whether the sandbox may reach the public internet",
     )
+    auto_idle_timeout_seconds: int | None = Field(
+        default=None,
+        serialization_alias="autoIdleTimeoutSeconds",
+        description="Per-sandbox auto-idle override in seconds",
+    )
     env_vars: list[EnvVar] | None = Field(
         default=None,
         serialization_alias="envVars",
@@ -160,6 +174,10 @@ class PoolInfo(BaseModel):
     image: str | None = Field(default=None, description="Container image")
     cpu: str | None = Field(default=None, description="CPU resource request")
     memory: str | None = Field(default=None, description="Memory resource request")
+    auto_idle_timeout_seconds: int | None = Field(
+        default=None,
+        description="Default auto-idle timeout in seconds for claimed sandboxes",
+    )
 
 
 class CreatePoolRequest(BaseModel):
@@ -176,6 +194,11 @@ class CreatePoolRequest(BaseModel):
         default=None,
         serialization_alias="allowInternetAccess",
         description="Whether sandboxes in the pool may reach the public internet",
+    )
+    auto_idle_timeout_seconds: int | None = Field(
+        default=None,
+        serialization_alias="autoIdleTimeoutSeconds",
+        description="Default auto-idle timeout in seconds for claimed sandboxes",
     )
     env_vars: list[EnvVar] | None = Field(
         default=None,
@@ -237,9 +260,7 @@ class BatchFileWriteResponse(BaseModel):
 
     success: bool = Field(..., description="True when all requested writes succeeded")
     total: int = Field(..., description="Total number of file writes requested")
-    success_count: int = Field(
-        ..., description="Number of successful file writes"
-    )
+    success_count: int = Field(..., description="Number of successful file writes")
     failure_count: int = Field(..., description="Number of failed file writes")
     results: list[BatchFileWriteResult] = Field(
         default_factory=list, description="Per-file results in request order"

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -8,6 +8,14 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
+def parse_auto_idle_timeout(response: dict[str, object]) -> int | None:
+    """Parse auto-idle timeout from either backend field alias."""
+    value = response.get(
+        "autoIdleTimeoutSeconds", response.get("auto_idle_timeout_seconds")
+    )
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 class SandboxStatus(str, Enum):
     """Status of a sandbox."""
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -129,6 +129,7 @@ class ClaimRequest(BaseModel):
     )
     auto_idle_timeout_seconds: int | None = Field(
         default=None,
+        strict=True,
         serialization_alias="autoIdleTimeoutSeconds",
         description="Per-claim auto-idle override in seconds",
     )
@@ -157,6 +158,7 @@ class CreateRequest(BaseModel):
     )
     auto_idle_timeout_seconds: int | None = Field(
         default=None,
+        strict=True,
         serialization_alias="autoIdleTimeoutSeconds",
         description="Per-sandbox auto-idle override in seconds",
     )
@@ -205,6 +207,7 @@ class CreatePoolRequest(BaseModel):
     )
     auto_idle_timeout_seconds: int | None = Field(
         default=None,
+        strict=True,
         serialization_alias="autoIdleTimeoutSeconds",
         description="Default auto-idle timeout in seconds for claimed sandboxes",
     )

--- a/src/prokube/sandbox/pool.py
+++ b/src/prokube/sandbox/pool.py
@@ -50,6 +50,7 @@ class SandboxPool:
         image: str | None = None,
         cpu: str | None = None,
         memory: str | None = None,
+        auto_idle_timeout_seconds: int | None = None,
     ) -> None:
         """Initialize a SandboxPool instance.
 
@@ -65,6 +66,7 @@ class SandboxPool:
             image: Container image.
             cpu: CPU resource request.
             memory: Memory resource request.
+            auto_idle_timeout_seconds: Default auto-idle timeout in seconds.
         """
         self._name = name
         self._workspace = workspace
@@ -74,6 +76,7 @@ class SandboxPool:
         self._image = image
         self._cpu = cpu
         self._memory = memory
+        self._auto_idle_timeout_seconds = auto_idle_timeout_seconds
         self._deleted = False
 
     @property
@@ -116,6 +119,11 @@ class SandboxPool:
         """Get the memory resource request."""
         return self._memory
 
+    @property
+    def auto_idle_timeout_seconds(self) -> int | None:
+        """Get the default auto-idle timeout for claimed sandboxes, if known."""
+        return self._auto_idle_timeout_seconds
+
     def _check_not_deleted(self) -> None:
         """Raise if pool has been deleted."""
         if self._deleted:
@@ -153,6 +161,8 @@ class SandboxPool:
         self._image = info.image
         self._cpu = info.cpu
         self._memory = info.memory
+        if info.auto_idle_timeout_seconds is not None:
+            self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
 
     @classmethod
     def create(
@@ -164,6 +174,7 @@ class SandboxPool:
         memory: str,
         *,
         allow_internet_access: bool | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
         api_url: str | None = None,
@@ -182,6 +193,8 @@ class SandboxPool:
             memory: Memory resource request (e.g. '4Gi').
             allow_internet_access: Whether sandboxes in the pool may reach the
                 public internet. If None, the backend default is used.
+            auto_idle_timeout_seconds: Default auto-idle timeout in seconds for
+                sandboxes claimed from this pool.
             env_vars: Environment variables to inject into pool sandboxes. Each
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into pool
@@ -223,6 +236,7 @@ class SandboxPool:
                 cpu=cpu,
                 memory=memory,
                 allow_internet_access=allow_internet_access,
+                auto_idle_timeout_seconds=auto_idle_timeout_seconds,
                 env_vars=env_vars,
                 secret_refs=secret_refs,
             )
@@ -239,6 +253,11 @@ class SandboxPool:
             image=info.image,
             cpu=info.cpu,
             memory=info.memory,
+            auto_idle_timeout_seconds=(
+                info.auto_idle_timeout_seconds
+                if info.auto_idle_timeout_seconds is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     @classmethod
@@ -305,6 +324,7 @@ class SandboxPool:
                         image=info.image,
                         cpu=info.cpu,
                         memory=info.memory,
+                        auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
                     )
                 )
         except Exception:
@@ -365,6 +385,7 @@ class SandboxPool:
             image=info.image,
             cpu=info.cpu,
             memory=info.memory,
+            auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
         )
 
     @staticmethod

--- a/src/prokube/sandbox/pool_client.py
+++ b/src/prokube/sandbox/pool_client.py
@@ -6,17 +6,14 @@ from typing import TYPE_CHECKING
 
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.http import HttpClient
-from prokube.sandbox.models import CreatePoolRequest, PoolInfo
+from prokube.sandbox.models import (
+    CreatePoolRequest,
+    PoolInfo,
+    parse_auto_idle_timeout,
+)
 
 if TYPE_CHECKING:
     from prokube.common.config import Config
-
-
-def _auto_idle_timeout(response: dict[str, object]) -> int | None:
-    value = response.get(
-        "autoIdleTimeoutSeconds", response.get("auto_idle_timeout_seconds")
-    )
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 class PoolClient:
@@ -57,6 +54,7 @@ class PoolClient:
         pool_size: int,
         cpu: str,
         memory: str,
+        *,
         allow_internet_access: bool | None = None,
         auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
@@ -98,7 +96,7 @@ class PoolClient:
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
         status = response.get("status", {})
-        response_auto_idle_timeout = _auto_idle_timeout(response)
+        response_auto_idle_timeout = parse_auto_idle_timeout(response)
         return PoolInfo(
             name=response.get("name", name),
             workspace=self.config.workspace,
@@ -139,7 +137,7 @@ class PoolClient:
                     image=p.get("image"),
                     cpu=p.get("cpu"),
                     memory=p.get("memory"),
-                    auto_idle_timeout_seconds=_auto_idle_timeout(p),
+                    auto_idle_timeout_seconds=parse_auto_idle_timeout(p),
                 )
             )
         return result
@@ -166,7 +164,7 @@ class PoolClient:
             image=response.get("image"),
             cpu=response.get("cpu"),
             memory=response.get("memory"),
-            auto_idle_timeout_seconds=_auto_idle_timeout(response),
+            auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
         )
 
     def delete_pool(self, name: str) -> None:

--- a/src/prokube/sandbox/pool_client.py
+++ b/src/prokube/sandbox/pool_client.py
@@ -54,11 +54,10 @@ class PoolClient:
         pool_size: int,
         cpu: str,
         memory: str,
-        *,
         allow_internet_access: bool | None = None,
-        auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
+        auto_idle_timeout_seconds: int | None = None,
     ) -> PoolInfo:
         """Create a new sandbox pool.
 
@@ -70,12 +69,12 @@ class PoolClient:
             memory: Memory resource request (e.g. '4Gi').
             allow_internet_access: Whether pool sandboxes may reach the public
                 internet. If None, the backend default is used.
-            auto_idle_timeout_seconds: Default auto-idle timeout in seconds for
-                sandboxes claimed from this pool.
             env_vars: Environment variables to inject into pool sandboxes. Each
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into pool
                 sandboxes.
+            auto_idle_timeout_seconds: Default auto-idle timeout in seconds for
+                sandboxes claimed from this pool.
 
         Returns:
             Information about the created pool.

--- a/src/prokube/sandbox/pool_client.py
+++ b/src/prokube/sandbox/pool_client.py
@@ -12,6 +12,13 @@ if TYPE_CHECKING:
     from prokube.common.config import Config
 
 
+def _auto_idle_timeout(response: dict[str, object]) -> int | None:
+    value = response.get(
+        "autoIdleTimeoutSeconds", response.get("auto_idle_timeout_seconds")
+    )
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 class PoolClient:
     """Client for sandbox pool API operations."""
 
@@ -51,6 +58,7 @@ class PoolClient:
         cpu: str,
         memory: str,
         allow_internet_access: bool | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
     ) -> PoolInfo:
@@ -64,6 +72,8 @@ class PoolClient:
             memory: Memory resource request (e.g. '4Gi').
             allow_internet_access: Whether pool sandboxes may reach the public
                 internet. If None, the backend default is used.
+            auto_idle_timeout_seconds: Default auto-idle timeout in seconds for
+                sandboxes claimed from this pool.
             env_vars: Environment variables to inject into pool sandboxes. Each
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into pool
@@ -79,6 +89,7 @@ class PoolClient:
             cpu=cpu,
             memory=memory,
             allow_internet_access=allow_internet_access,
+            auto_idle_timeout_seconds=auto_idle_timeout_seconds,
             env_vars=env_vars,
             secret_refs=secret_refs,
         )
@@ -87,16 +98,23 @@ class PoolClient:
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
         status = response.get("status", {})
+        response_auto_idle_timeout = _auto_idle_timeout(response)
         return PoolInfo(
             name=response.get("name", name),
             workspace=self.config.workspace,
             replicas=response.get("replicas", response.get("poolSize", pool_size)),
             ready_replicas=status.get(
-                "warmPods", status.get("availablePods", response.get("readyReplicas", 0))
+                "warmPods",
+                status.get("availablePods", response.get("readyReplicas", 0)),
             ),
             image=response.get("image", image),
             cpu=response.get("cpu", cpu),
             memory=response.get("memory", memory),
+            auto_idle_timeout_seconds=(
+                response_auto_idle_timeout
+                if response_auto_idle_timeout is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     def list_pools(self) -> list[PoolInfo]:
@@ -121,6 +139,7 @@ class PoolClient:
                     image=p.get("image"),
                     cpu=p.get("cpu"),
                     memory=p.get("memory"),
+                    auto_idle_timeout_seconds=_auto_idle_timeout(p),
                 )
             )
         return result
@@ -141,11 +160,13 @@ class PoolClient:
             workspace=self.config.workspace,
             replicas=response.get("replicas", response.get("poolSize", 0)),
             ready_replicas=status.get(
-                "warmPods", status.get("availablePods", response.get("readyReplicas", 0))
+                "warmPods",
+                status.get("availablePods", response.get("readyReplicas", 0)),
             ),
             image=response.get("image"),
             cpu=response.get("cpu"),
             memory=response.get("memory"),
+            auto_idle_timeout_seconds=_auto_idle_timeout(response),
         )
 
     def delete_pool(self, name: str) -> None:

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -13,7 +13,7 @@ else:
     from typing_extensions import Self
 
 from prokube.common.config import Config
-from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.common.exceptions import ProKubeError, SandboxError, SandboxTimeoutError
 from prokube.sandbox.client import SandboxClient
 from prokube.sandbox.code import CodeRunner
 from prokube.sandbox.commands import CommandRunner
@@ -321,7 +321,15 @@ class Sandbox:
             # Cap each probe so retries stay frequent against a stuck kernel,
             # while still never exceeding the remaining wait_until_ready budget.
             probe_timeout = min(max_probe_timeout, int(remaining))
-            result = self.run_code(code, timeout=probe_timeout)
+            try:
+                result = self.run_code(code, timeout=probe_timeout)
+            except ProKubeError as exc:
+                if exc.status_code != 504:
+                    raise
+                self._code.reset_session()
+                sleep_for = min(0.5, max(0.0, deadline - time.monotonic()))
+                time.sleep(sleep_for)
+                continue
             if result.stdout.strip() == marker:
                 return
             self._code.reset_session()

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -64,6 +64,7 @@ class Sandbox:
         status: SandboxStatus = SandboxStatus.RUNNING,
         pool: str | None = None,
         image: str | None = None,
+        auto_idle_timeout_seconds: int | None = None,
     ) -> None:
         """Initialize a Sandbox instance.
 
@@ -77,6 +78,7 @@ class Sandbox:
             status: Current sandbox status.
             pool: WarmPool name if claimed from pool.
             image: Container image if created directly.
+            auto_idle_timeout_seconds: Auto-idle timeout override in seconds.
         """
         self._name = name
         self._workspace = workspace
@@ -84,6 +86,7 @@ class Sandbox:
         self._status = status
         self._pool = pool
         self._image = image
+        self._auto_idle_timeout_seconds = auto_idle_timeout_seconds
         self._killed = False
         self._skip_next_warmup = False
 
@@ -184,6 +187,11 @@ class Sandbox:
         """
         return self._code.session_id
 
+    @property
+    def auto_idle_timeout_seconds(self) -> int | None:
+        """Get the configured auto-idle timeout override in seconds, if known."""
+        return self._auto_idle_timeout_seconds
+
     def pause(self) -> None:
         """Pause the sandbox. Frees compute resources.
 
@@ -213,6 +221,8 @@ class Sandbox:
         self._check_not_killed()
         info = self._client.resume(self._name)
         self._status = info.status
+        if info.auto_idle_timeout_seconds is not None:
+            self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
         self._skip_next_warmup = info.resumed_from_pool
         # New pod means previous Jupyter session is invalid.
         self._code.reset_session()
@@ -341,6 +351,8 @@ class Sandbox:
         self._check_not_killed()
         info = self._client.get(self._name)
         self._status = info.status
+        if info.auto_idle_timeout_seconds is not None:
+            self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
 
     @classmethod
     def from_pool(
@@ -351,6 +363,7 @@ class Sandbox:
         workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         timeout: int | None = None,
     ) -> Self:
         """Claim a sandbox from a warm pool.
@@ -364,6 +377,7 @@ class Sandbox:
             workspace: Workspace (default: from PROKUBE_WORKSPACE env var).
             user_id: User ID (default: from PROKUBE_USER_ID env var).
             api_key: API key for external access (default: from PROKUBE_API_KEY env var).
+            auto_idle_timeout_seconds: Per-claim auto-idle override in seconds.
             timeout: Request timeout (default: from PROKUBE_TIMEOUT env var).
 
         Returns:
@@ -382,7 +396,9 @@ class Sandbox:
         )
         client = SandboxClient(config)
         try:
-            info = client.claim_from_pool(pool)
+            info = client.claim_from_pool(
+                pool, auto_idle_timeout_seconds=auto_idle_timeout_seconds
+            )
         except Exception:
             client.close()
             raise
@@ -393,6 +409,11 @@ class Sandbox:
             client=client,
             status=info.status,
             pool=pool,
+            auto_idle_timeout_seconds=(
+                info.auto_idle_timeout_seconds
+                if info.auto_idle_timeout_seconds is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     @classmethod
@@ -462,6 +483,7 @@ class Sandbox:
                         status=info.status,
                         pool=info.pool,
                         image=info.image,
+                        auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
                     )
                 )
         except Exception:
@@ -523,6 +545,7 @@ class Sandbox:
             status=info.status,
             pool=info.pool,
             image=info.image,
+            auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
         )
 
     # Alias: Sandbox.connect() is the same as Sandbox.get()
@@ -537,6 +560,7 @@ class Sandbox:
         cpu: str | None = None,
         memory: str | None = None,
         allow_internet_access: bool | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         env_vars: list[dict[str, str]] | None = None,
         secret_refs: list[str] | None = None,
         api_url: str | None = None,
@@ -559,6 +583,7 @@ class Sandbox:
                 default is used.
             allow_internet_access: Whether the sandbox may reach the public
                 internet. If None, the backend default is used.
+            auto_idle_timeout_seconds: Per-sandbox auto-idle override in seconds.
             env_vars: Environment variables to inject into the sandbox. Each
                 entry is a ``{"name": ..., "value": ...}`` dict.
             secret_refs: Names of workspace secrets to mount into the sandbox.
@@ -601,6 +626,7 @@ class Sandbox:
                 cpu=cpu,
                 memory=memory,
                 allow_internet_access=allow_internet_access,
+                auto_idle_timeout_seconds=auto_idle_timeout_seconds,
                 env_vars=env_vars,
                 secret_refs=secret_refs,
             )
@@ -614,6 +640,11 @@ class Sandbox:
             client=client,
             status=info.status,
             image=image,
+            auto_idle_timeout_seconds=(
+                info.auto_idle_timeout_seconds
+                if info.auto_idle_timeout_seconds is not None
+                else auto_idle_timeout_seconds
+            ),
         )
 
     @staticmethod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,6 +89,7 @@ class TestListSandboxes:
                         "phase": "Running",
                         "poolName": "python-pool",
                         "createdAt": "2026-01-01T00:00:00Z",
+                        "auto_idle_timeout_seconds": 900,
                     },
                     {
                         "name": "sandbox-2",
@@ -110,9 +111,35 @@ class TestListSandboxes:
         assert result[0].image == "python:3.10"
         assert result[0].pool == "python-pool"
         assert result[0].created_at == "2026-01-01T00:00:00Z"
+        assert result[0].auto_idle_timeout_seconds == 900
         assert result[1].name == "sandbox-2"
         assert result[1].status == SandboxStatus.PENDING
         assert result[1].pool is None
+        client.close()
+
+    def test_claim_sends_auto_idle_timeout(self, config, httpx_mock: HTTPXMock):
+        """claim_from_pool sends per-claim auto-idle override."""
+        import json
+
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-test", "status": "Running"},
+        )
+
+        client = SandboxClient(config)
+        info = client.claim_from_pool("python-pool", auto_idle_timeout_seconds=900)
+
+        post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        body = json.loads(post_req.content)
+        assert body["poolName"] == "python-pool"
+        assert body["autoIdleTimeoutSeconds"] == 900
+        assert info.auto_idle_timeout_seconds == 900
         client.close()
 
     def test_list_with_status_field(self, config, httpx_mock: HTTPXMock):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,10 +3,18 @@
 import pytest
 
 from prokube.sandbox.client import _parse_batch_file_write_response
-from prokube.sandbox.models import (BatchFileWriteResponse, ClaimRequest,
-                                    CodeResult, CommandResult, CreateRequest,
-                                    ExecRequest, FileInfo, FileWriteRequest,
-                                    SandboxInfo, SandboxStatus)
+from prokube.sandbox.models import (
+    BatchFileWriteResponse,
+    ClaimRequest,
+    CodeResult,
+    CommandResult,
+    CreateRequest,
+    ExecRequest,
+    FileInfo,
+    FileWriteRequest,
+    SandboxInfo,
+    SandboxStatus,
+)
 
 
 class TestSandboxStatus:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,18 +3,10 @@
 import pytest
 
 from prokube.sandbox.client import _parse_batch_file_write_response
-from prokube.sandbox.models import (
-    BatchFileWriteResponse,
-    ClaimRequest,
-    CodeResult,
-    CommandResult,
-    CreateRequest,
-    ExecRequest,
-    FileInfo,
-    FileWriteRequest,
-    SandboxInfo,
-    SandboxStatus,
-)
+from prokube.sandbox.models import (BatchFileWriteResponse, ClaimRequest,
+                                    CodeResult, CommandResult, CreateRequest,
+                                    ExecRequest, FileInfo, FileWriteRequest,
+                                    SandboxInfo, SandboxStatus)
 
 
 class TestSandboxStatus:
@@ -51,10 +43,12 @@ class TestSandboxInfo:
             image="python:3.10",
             pool="my-pool",
             created_at="2024-01-01T00:00:00Z",
+            auto_idle_timeout_seconds=1800,
         )
         assert info.status == SandboxStatus.RUNNING
         assert info.image == "python:3.10"
         assert info.pool == "my-pool"
+        assert info.auto_idle_timeout_seconds == 1800
 
 
 class TestCommandResult:
@@ -165,16 +159,24 @@ class TestRequestModels:
 
     def test_claim_request(self):
         """Test ClaimRequest."""
-        req = ClaimRequest(pool_name="python-pool")
+        req = ClaimRequest(pool_name="python-pool", auto_idle_timeout_seconds=900)
         assert req.pool_name == "python-pool"
         # Check it serializes with camelCase alias
-        assert req.model_dump(by_alias=True) == {"poolName": "python-pool"}
+        assert req.model_dump(by_alias=True) == {
+            "poolName": "python-pool",
+            "autoIdleTimeoutSeconds": 900,
+        }
 
     def test_create_request(self):
         """Test CreateRequest."""
-        req = CreateRequest(image="python:3.10", name="my-sandbox")
+        req = CreateRequest(
+            image="python:3.10",
+            name="my-sandbox",
+            auto_idle_timeout_seconds=1800,
+        )
         assert req.image == "python:3.10"
         assert req.name == "my-sandbox"
+        assert req.model_dump(by_alias=True)["autoIdleTimeoutSeconds"] == 1800
 
     def test_file_write_request(self):
         """Test FileWriteRequest."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 """Tests for Pydantic models."""
 
 import pytest
+from pydantic import ValidationError
 
 from prokube.sandbox.client import _parse_batch_file_write_response
 from prokube.sandbox.models import (
@@ -8,6 +9,7 @@ from prokube.sandbox.models import (
     ClaimRequest,
     CodeResult,
     CommandResult,
+    CreatePoolRequest,
     CreateRequest,
     ExecRequest,
     FileInfo,
@@ -175,6 +177,11 @@ class TestRequestModels:
             "autoIdleTimeoutSeconds": 900,
         }
 
+    def test_claim_request_rejects_bool_auto_idle_timeout(self):
+        """Auto-idle timeout must be an integer, not a boolean."""
+        with pytest.raises(ValidationError):
+            ClaimRequest(pool_name="python-pool", auto_idle_timeout_seconds=True)
+
     def test_create_request(self):
         """Test CreateRequest."""
         req = CreateRequest(
@@ -185,6 +192,23 @@ class TestRequestModels:
         assert req.image == "python:3.10"
         assert req.name == "my-sandbox"
         assert req.model_dump(by_alias=True)["autoIdleTimeoutSeconds"] == 1800
+
+    def test_create_request_rejects_bool_auto_idle_timeout(self):
+        """Auto-idle timeout must be an integer, not a boolean."""
+        with pytest.raises(ValidationError):
+            CreateRequest(image="python:3.10", auto_idle_timeout_seconds=True)
+
+    def test_create_pool_request_rejects_bool_auto_idle_timeout(self):
+        """Auto-idle timeout must be an integer, not a boolean."""
+        with pytest.raises(ValidationError):
+            CreatePoolRequest(
+                name="python-pool",
+                image="python:3.10",
+                pool_size=3,
+                cpu="2",
+                memory="4Gi",
+                auto_idle_timeout_seconds=True,
+            )
 
     def test_file_write_request(self):
         """Test FileWriteRequest."""

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -637,6 +637,52 @@ class TestWaitUntilReady:
 
         sbx._client.close()
 
+    def test_wait_until_ready_retries_warmup_gateway_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Transient Agent Gateway 504s during warmup are retried."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
+
+        call_counter = {"n": 0}
+
+        def _probe_callback(request: httpx.Request) -> httpx.Response:
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return httpx.Response(504, text="upstream request timeout")
+            marker = _extract_marker(request) or ""
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": f"{marker}\n",
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                },
+            )
+
+        httpx_mock.add_callback(
+            _probe_callback,
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=5)
+
+        assert sbx.status == "Running"
+        assert call_counter["n"] == 2
+
+        sbx._client.close()
+
     def test_wait_until_ready_warmup_caps_per_probe_timeout(
         self, mock_env, monkeypatch, httpx_mock: HTTPXMock
     ):

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -343,6 +343,29 @@ class TestSandboxResume:
 
         sbx._client.close()
 
+    def test_resume_preserves_known_auto_idle_timeout(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            json={"status": "ok"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool", auto_idle_timeout_seconds=900)
+        sbx.pause()
+        sbx.resume()
+
+        assert sbx.auto_idle_timeout_seconds == 900
+        sbx._client.close()
+
     def test_resume_non_paused_raises(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -10,7 +10,6 @@ from prokube.common.exceptions import SandboxError
 from prokube.sandbox.pool import SandboxPool
 from prokube.sandbox.pool_client import PoolClient
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -180,6 +179,7 @@ class TestPoolClientCreateExtras:
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
         body = json.loads(post_req.content)
         assert "allowInternetAccess" not in body
+        assert "autoIdleTimeoutSeconds" not in body
         assert "envVars" not in body
         assert "secretRefs" not in body
         client.close()
@@ -207,6 +207,7 @@ class TestPoolClientCreateExtras:
             cpu="2",
             memory="4Gi",
             allow_internet_access=True,
+            auto_idle_timeout_seconds=600,
             env_vars=[
                 {"name": "FOO", "value": "bar"},
                 {"name": "HELLO", "value": "world"},
@@ -217,6 +218,7 @@ class TestPoolClientCreateExtras:
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
         body = json.loads(post_req.content)
         assert body["allowInternetAccess"] is True
+        assert body["autoIdleTimeoutSeconds"] == 600
         assert body["envVars"] == [
             {"name": "FOO", "value": "bar"},
             {"name": "HELLO", "value": "world"},
@@ -224,6 +226,7 @@ class TestPoolClientCreateExtras:
         assert body["secretRefs"] == ["openai-key", "hf-token"]
         # snake_case must NOT leak into the wire format
         assert "allow_internet_access" not in body
+        assert "auto_idle_timeout_seconds" not in body
         assert "env_vars" not in body
         assert "secret_refs" not in body
         client.close()
@@ -247,6 +250,7 @@ class TestSandboxPoolCreateExtras:
             cpu="2",
             memory="4Gi",
             allow_internet_access=False,
+            auto_idle_timeout_seconds=600,
             env_vars=[{"name": "DEBUG", "value": "1"}],
             secret_refs=["db-creds"],
         )
@@ -254,6 +258,7 @@ class TestSandboxPoolCreateExtras:
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
         body = json.loads(post_req.content)
         assert body["allowInternetAccess"] is False
+        assert body["autoIdleTimeoutSeconds"] == 600
         assert body["envVars"] == [{"name": "DEBUG", "value": "1"}]
         assert body["secretRefs"] == ["db-creds"]
         pool._client.close()
@@ -276,7 +281,12 @@ class TestSandboxPoolCreateExtras:
 
         post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][0]
         body = json.loads(post_req.content)
-        for key in ("allowInternetAccess", "envVars", "secretRefs"):
+        for key in (
+            "allowInternetAccess",
+            "autoIdleTimeoutSeconds",
+            "envVars",
+            "secretRefs",
+        ):
             assert key not in body
         pool._client.close()
 
@@ -319,6 +329,7 @@ class TestPoolClientList:
                         "image": "img-a",
                         "cpu": "1",
                         "memory": "2Gi",
+                        "auto_idle_timeout_seconds": 900,
                     },
                     {
                         "name": "pool-b",
@@ -338,6 +349,7 @@ class TestPoolClientList:
         assert pools[0].name == "pool-a"
         assert pools[0].replicas == 2
         assert pools[0].ready_replicas == 1
+        assert pools[0].auto_idle_timeout_seconds == 900
         assert pools[1].name == "pool-b"
         assert pools[1].replicas == 5
         assert pools[1].ready_replicas == 5
@@ -356,7 +368,7 @@ class TestPoolClientGet:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
-            json=POOL_RESPONSE,
+            json={**POOL_RESPONSE, "autoIdleTimeoutSeconds": 1200},
         )
 
         client = PoolClient(config)
@@ -365,6 +377,7 @@ class TestPoolClientGet:
         assert info.replicas == 3
         assert info.ready_replicas == 2
         assert info.workspace == "test-ws"
+        assert info.auto_idle_timeout_seconds == 1200
         client.close()
 
 
@@ -430,6 +443,7 @@ class TestSandboxPoolCreate:
         assert pool.pool_size == 3
         assert pool.ready_replicas == 2
         assert pool.image == "pk-sandbox-base:latest"
+        assert pool.auto_idle_timeout_seconds is None
         pool._client.close()
 
 
@@ -461,6 +475,7 @@ class TestSandboxPoolList:
                         "image": "img-a",
                         "cpu": "1",
                         "memory": "2Gi",
+                        "autoIdleTimeoutSeconds": 900,
                     },
                     {
                         "name": "pool-b",
@@ -478,6 +493,7 @@ class TestSandboxPoolList:
         assert len(pools) == 2
         assert pools[0].name == "pool-a"
         assert pools[0].workspace == "test-ws"
+        assert pools[0].auto_idle_timeout_seconds == 900
         assert pools[1].name == "pool-b"
 
         for p in pools:
@@ -492,13 +508,14 @@ class TestSandboxPoolGet:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
-            json=POOL_RESPONSE,
+            json={**POOL_RESPONSE, "auto_idle_timeout_seconds": 1200},
         )
 
         pool = SandboxPool.get("python-pool")
         assert pool.name == "python-pool"
         assert pool.workspace == "test-ws"
         assert pool.pool_size == 3
+        assert pool.auto_idle_timeout_seconds == 1200
         pool._client.close()
 
 
@@ -597,6 +614,27 @@ class TestSandboxPoolRefresh:
 
         pool.refresh()
         assert pool.ready_replicas == 3
+
+        pool._client.close()
+
+    def test_refresh_preserves_known_auto_idle_timeout(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            json={**POOL_RESPONSE, "autoIdleTimeoutSeconds": 1200},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            json=POOL_RESPONSE,
+        )
+
+        pool = SandboxPool.get("python-pool")
+        pool.refresh()
+        assert pool.auto_idle_timeout_seconds == 1200
 
         pool._client.close()
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -151,6 +151,31 @@ class TestSandboxFromPool:
 
         sbx._client.close()
 
+    def test_claim_from_pool_with_auto_idle_timeout(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """from_pool forwards and stores per-claim auto-idle override."""
+        import json
+
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            json={"name": "sandbox-abc123", "status": "Running"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool", auto_idle_timeout_seconds=900)
+
+        claim_request = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        body = json.loads(claim_request.content)
+        assert body["autoIdleTimeoutSeconds"] == 900
+        assert sbx.auto_idle_timeout_seconds == 900
+        sbx._client.close()
+
 
 class TestSandboxCreate:
     """Tests for Sandbox.create()."""
@@ -204,6 +229,7 @@ class TestSandboxCreate:
             "cpu",
             "memory",
             "allowInternetAccess",
+            "autoIdleTimeoutSeconds",
             "envVars",
             "secretRefs",
         ):
@@ -247,6 +273,7 @@ class TestSandboxCreate:
         assert body["cpu"] == "2"
         assert body["memory"] == "4Gi"
         assert body["allowInternetAccess"] is True
+        assert "autoIdleTimeoutSeconds" not in body
         assert body["envVars"] == [
             {"name": "FOO", "value": "bar"},
             {"name": "HELLO", "value": "world"},
@@ -257,6 +284,35 @@ class TestSandboxCreate:
         assert "env_vars" not in body
         assert "secret_refs" not in body
 
+        sbx._client.close()
+
+    def test_create_sandbox_with_auto_idle_timeout(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """create forwards and stores per-sandbox auto-idle override."""
+        import json
+
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            json={"name": "sandbox-abc", "status": "Pending"},
+        )
+
+        sbx = Sandbox.create(
+            image="python:3.10",
+            name="sandbox-abc",
+            auto_idle_timeout_seconds=1800,
+        )
+
+        post_req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        body = json.loads(post_req.content)
+        assert body["autoIdleTimeoutSeconds"] == 1800
+        assert sbx.auto_idle_timeout_seconds == 1800
         sbx._client.close()
 
 


### PR DESCRIPTION
## Summary
- add `auto_idle_timeout_seconds` to sandbox create, warm-pool create, and pool claim requests
- expose auto-idle timeout metadata on `Sandbox`, `SandboxPool`, `SandboxInfo`, and `PoolInfo`
- parse both camelCase and snake_case backend response fields
- preserve known timeout metadata when refresh/resume responses omit it

## Testing
- `PYTHONPATH=src uv run pytest tests -q` (183 passed)
