### PR TITLE
fix: Route internal sandbox SDK through Agent Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,35 @@ Configuration can be provided via environment variables or explicitly:
 ### Environment Variables
 
 ```bash
-export PROKUBE_API_URL=https://prokube.ai/pkui  # Can include path prefix
 export PROKUBE_WORKSPACE=my-workspace
-export PROKUBE_USER_ID=user@example.com  # Required if no API key (or KF_USER)
+export PROKUBE_API_URL=https://prokube.ai/pkui  # Required for external access
 export PROKUBE_TIMEOUT=300  # Optional, default 300 seconds
 ```
 
-**Note:** Authentication requires one of: `PROKUBE_API_KEY`, `PROKUBE_USER_ID`, or
-`KF_USER` (precedence in that order). `PROKUBE_API_KEY` enables external access;
-`PROKUBE_USER_ID` and `KF_USER` are for in-cluster usage. If none are set, you must
-pass `api_key` or `user_id` explicitly when creating a Sandbox.
+**Note:** In-cluster Agent Gateway access does not require SDK auth credentials.
+`PROKUBE_API_KEY` enables external access and takes precedence over `PROKUBE_USER_ID`
+or `KF_USER` when present.
+
+### In-Cluster Notebooks
+
+Inside a prokube.ai workspace notebook, only the workspace namespace is required.
+If `PROKUBE_API_URL` is not set, the SDK defaults to the in-cluster Agent Gateway
+service and routes sandbox traffic through `/_platform/sandbox/<workspace>`.
+
+```bash
+export PROKUBE_WORKSPACE=henrik
+```
+
+```python
+from prokube.sandbox import Sandbox
+
+with Sandbox.from_pool("python-pool") as sbx:
+    result = sbx.run_code("print('Hello from inside the workspace!')")
+    print(result.stdout)
+```
+
+This uses:
+`http://agentgateway-proxy.agentgateway-system.svc.cluster.local/_platform/sandbox/henrik/sandboxes/claim`.
 
 ### Explicit Configuration
 

--- a/src/prokube/common/auth.py
+++ b/src/prokube/common/auth.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from prokube.common.config import Config
-from prokube.common.exceptions import AuthenticationError
 
 
 def get_auth_headers(config: Config) -> dict[str, str]:
     """Get authentication headers for API requests.
 
     If api_key is set, uses API key authentication (x-api-key header).
-    Otherwise falls back to user_id authentication (kubeflow-userid header).
+    Otherwise falls back to user_id authentication (kubeflow-userid header) when
+    provided. In-cluster Agent Gateway access can run without SDK auth headers.
 
     Args:
         config: SDK configuration containing api_key and/or user_id.
@@ -18,16 +18,10 @@ def get_auth_headers(config: Config) -> dict[str, str]:
     Returns:
         Dictionary of headers to include in API requests.
 
-    Raises:
-        AuthenticationError: If neither api_key nor user_id is available.
     """
     if config.api_key:
         return {"x-api-key": config.api_key}
     if config.user_id:
         return {"kubeflow-userid": config.user_id}
 
-    raise AuthenticationError(
-        "No api_key or user_id available for authentication. "
-        "Set PROKUBE_API_KEY, PROKUBE_USER_ID, or KF_USER environment variable, "
-        "or pass api_key/user_id parameter to the Sandbox."
-    )
+    return {}

--- a/src/prokube/common/config.py
+++ b/src/prokube/common/config.py
@@ -12,18 +12,18 @@ class Config:
 
     Configuration can be provided explicitly or via environment variables:
     - PROKUBE_API_URL: Base URL for the prokube API (e.g., "https://prokube.ai/pkui").
-      Can include a path prefix; the SDK appends "/api/..." (internal) or
-      "/sandbox/..." (external, when using API key auth) paths to this URL.
-      Do NOT include "/api" or "/sandbox" in this URL - use the base UI URL instead.
+      External API key access can include a path prefix; the SDK strips it and
+      calls top-level "/sandbox/..." endpoints. In-cluster access defaults to
+      Agent Gateway and calls "/_platform/sandbox/..." endpoints.
+      Do NOT include "/api", "/_platform", or "/sandbox" in this URL.
     - PROKUBE_WORKSPACE: Workspace (Kubernetes namespace)
     - PROKUBE_USER_ID: User ID for authentication
     - PROKUBE_API_KEY: API key for external access (takes precedence over user_id)
     - PROKUBE_TIMEOUT: Default timeout in seconds (default: 300)
 
     If both api_key and user_id are set, api_key takes precedence for authentication.
-    At least one of api_key or user_id must be available when making authenticated
-    requests (for example, when calling get_auth_headers()). This requirement is
-    validated at request time rather than during Config initialization.
+    In-cluster Agent Gateway access does not require credentials. External access
+    requires api_key.
     """
 
     api_url: str = field(default_factory=lambda: _get_api_url())
@@ -55,7 +55,10 @@ class Config:
 
 def _get_api_url() -> str:
     """Get API URL from environment."""
-    return os.environ.get("PROKUBE_API_URL", "")
+    return os.environ.get(
+        "PROKUBE_API_URL",
+        "http://agentgateway-proxy.agentgateway-system.svc.cluster.local",
+    )
 
 
 def _get_workspace() -> str:

--- a/src/prokube/common/config.py
+++ b/src/prokube/common/config.py
@@ -34,6 +34,10 @@ class Config:
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
+        if not self.api_url and not self.use_api_key:
+            self.api_url = (
+                "http://agentgateway-proxy.agentgateway-system.svc.cluster.local"
+            )
         if not self.api_url:
             raise ValueError(
                 "API URL is required. Set PROKUBE_API_URL environment variable "
@@ -55,10 +59,7 @@ class Config:
 
 def _get_api_url() -> str:
     """Get API URL from environment."""
-    return os.environ.get(
-        "PROKUBE_API_URL",
-        "http://agentgateway-proxy.agentgateway-system.svc.cluster.local",
-    )
+    return os.environ.get("PROKUBE_API_URL", "")
 
 
 def _get_workspace() -> str:

--- a/src/prokube/common/config.py
+++ b/src/prokube/common/config.py
@@ -34,7 +34,11 @@ class Config:
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
-        if not self.api_url and not self.use_api_key:
+        if (
+            not self.api_url
+            and not self.use_api_key
+            and os.environ.get("KUBERNETES_SERVICE_HOST")
+        ):
             self.api_url = (
                 "http://agentgateway-proxy.agentgateway-system.svc.cluster.local"
             )

--- a/src/prokube/common/http.py
+++ b/src/prokube/common/http.py
@@ -30,8 +30,8 @@ class HttpClient:
             # For API key (external) access, the external routes (/sandbox/*,
             # /mcp/*) are top-level on the ingress gateway — NOT under the path
             # prefix (e.g., /pkui). So we strip the path and use only the origin.
-            # For internal access, the full api_url (with prefix) is used since
-            # internal routes live under /pkui/api/...
+            # For in-cluster access, use the configured Agent Gateway base URL;
+            # sandbox paths are routed through /_platform/sandbox/...
             if self.config.use_api_key:
                 base_url = self._get_origin(self.config.api_url)
             else:

--- a/src/prokube/common/http.py
+++ b/src/prokube/common/http.py
@@ -30,8 +30,9 @@ class HttpClient:
             # For API key (external) access, the external routes (/sandbox/*,
             # /mcp/*) are top-level on the ingress gateway — NOT under the path
             # prefix (e.g., /pkui). So we strip the path and use only the origin.
-            # For in-cluster access, use the configured Agent Gateway base URL;
-            # sandbox paths are routed through /_platform/sandbox/...
+            # For internal access, preserve the configured api_url. By default
+            # this is the in-cluster Agent Gateway service, but callers may
+            # override it with another origin or path prefix.
             if self.config.use_api_key:
                 base_url = self._get_origin(self.config.api_url)
             else:

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -365,6 +365,9 @@ class SandboxClient:
         Args:
             name: Sandbox name.
 
+        Returns:
+            Updated sandbox information after the resume request.
+
         Raises:
             SandboxError: If sandbox is not in Paused state (HTTP 409).
         """
@@ -379,6 +382,10 @@ class SandboxClient:
         if isinstance(status_str, str) and status_str.lower() == "ok":
             status_str = None
 
+        resumed_from_pool = response.get("resumedFromPool")
+        if resumed_from_pool is None:
+            resumed_from_pool = response.get("resumed_from_pool") or False
+
         return SandboxInfo(
             name=response.get("name", name),
             workspace=self.config.workspace,
@@ -387,7 +394,7 @@ class SandboxClient:
             pool=response.get("poolName") or response.get("pool"),
             created_at=response.get("createdAt") or response.get("created_at"),
             auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
-            resumed_from_pool=response.get("resumedFromPool", False),
+            resumed_from_pool=resumed_from_pool,
         )
 
     def delete(self, name: str) -> None:

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -178,7 +178,7 @@ class SandboxClient:
         ws = self.config.workspace
         if self.config.use_api_key:
             return f"/sandbox/{ws}/sandboxes"
-        return f"/api/namespaces/{ws}/sandboxes"
+        return f"/_platform/sandbox/{ws}/sandboxes"
 
     def _sandbox_path(self, name: str) -> str:
         """Get API path for a specific sandbox."""

--- a/src/prokube/sandbox/pool_client.py
+++ b/src/prokube/sandbox/pool_client.py
@@ -41,7 +41,7 @@ class PoolClient:
         ws = self.config.workspace
         if self.config.use_api_key:
             return f"/sandbox/{ws}/sandbox-pools"
-        return f"/api/namespaces/{ws}/sandbox-pools"
+        return f"/_platform/sandbox/{ws}/sandbox-pools"
 
     def _pool_path(self, name: str) -> str:
         """Get API path for a specific pool."""

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -245,8 +245,16 @@ class Sandbox:
             self.refresh()
             if self._status == SandboxStatus.RUNNING:
                 if self._skip_next_warmup:
-                    self._skip_next_warmup = False
-                    return
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        self._skip_next_warmup = False
+                        return
+                    time.sleep(min(poll_interval, remaining))
+                    self.refresh()
+                    if self._status == SandboxStatus.RUNNING:
+                        self._skip_next_warmup = False
+                        return
+                    continue
                 self._warmup_kernel(deadline)
                 return
             if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -245,16 +245,8 @@ class Sandbox:
             self.refresh()
             if self._status == SandboxStatus.RUNNING:
                 if self._skip_next_warmup:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        self._skip_next_warmup = False
-                        return
-                    time.sleep(min(poll_interval, remaining))
-                    self.refresh()
-                    if self._status == SandboxStatus.RUNNING:
-                        self._skip_next_warmup = False
-                        return
-                    continue
+                    self._skip_next_warmup = False
+                    return
                 self._warmup_kernel(deadline)
                 return
             if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -239,7 +239,7 @@ class Sandbox:
                 while waiting for it to become ready.
         """
         self._check_not_killed()
-        poll_interval = 0.5
+        poll_interval = 2
         deadline = time.monotonic() + timeout
         while True:
             self.refresh()

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -8,7 +8,6 @@ from pytest_httpx import HTTPXMock
 
 from prokube.common.auth import get_auth_headers
 from prokube.common.config import Config
-from prokube.common.exceptions import AuthenticationError
 from prokube.sandbox import Sandbox
 from prokube.sandbox.client import SandboxClient
 
@@ -117,14 +116,13 @@ class TestAuthHeaders:
         headers = get_auth_headers(config)
         assert headers == {"x-api-key": "my-key"}
 
-    def test_no_credentials_raises(self):
-        """Test that missing both api_key and user_id raises."""
+    def test_no_credentials_returns_empty_headers(self):
+        """Test that in-cluster Agent Gateway access can run without SDK auth."""
         config = Config(
             api_url="https://example.com",
             workspace="test-ws",
         )
-        with pytest.raises(AuthenticationError, match="No api_key or user_id"):
-            get_auth_headers(config)
+        assert get_auth_headers(config) == {}
 
 
 class TestPathRouting:
@@ -138,7 +136,7 @@ class TestPathRouting:
             user_id="user@test.com",
         )
         client = SandboxClient(config, check_version=False)
-        assert client._sandboxes_path() == "/api/namespaces/test-ws/sandboxes"
+        assert client._sandboxes_path() == "/_platform/sandbox/test-ws/sandboxes"
         client.close()
 
     def test_external_sandboxes_path(self):
@@ -162,7 +160,7 @@ class TestPathRouting:
         client = SandboxClient(config, check_version=False)
         assert (
             client._sandbox_path("my-sbx")
-            == "/api/namespaces/test-ws/sandboxes/my-sbx"
+            == "/_platform/sandbox/test-ws/sandboxes/my-sbx"
         )
         client.close()
 
@@ -187,15 +185,15 @@ class TestPathRouting:
         client = SandboxClient(config, check_version=False)
         assert (
             client._sandbox_sub_path("my-sbx", "exec")
-            == "/api/namespaces/test-ws/sandboxes/my-sbx/exec"
+            == "/_platform/sandbox/test-ws/sandboxes/my-sbx/exec"
         )
         assert (
             client._sandbox_sub_path("my-sbx", "files")
-            == "/api/namespaces/test-ws/sandboxes/my-sbx/files"
+            == "/_platform/sandbox/test-ws/sandboxes/my-sbx/files"
         )
         assert (
             client._sandbox_sub_path("my-sbx", "files/download")
-            == "/api/namespaces/test-ws/sandboxes/my-sbx/files/download"
+            == "/_platform/sandbox/test-ws/sandboxes/my-sbx/files/download"
         )
         client.close()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,7 +60,7 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"sandboxes": [], "total": 0},
         )
 
@@ -79,7 +79,7 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {
@@ -128,7 +128,7 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
 
@@ -151,7 +151,7 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {
@@ -186,7 +186,7 @@ class TestReadFile:
         # Mock file download - path is passed as query parameter
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/test-sbx/files/download?path=%2Fworkspace%2Fmy+file.txt",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/test-sbx/files/download?path=%2Fworkspace%2Fmy+file.txt",
             content=b"content",
         )
 
@@ -207,7 +207,7 @@ class TestReadFile:
         # Mock file download - special chars in query param
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/test-sbx/files/download?path=%2Fworkspace%2Ffile%23%3F.txt",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/test-sbx/files/download?path=%2Fworkspace%2Ffile%23%3F.txt",
             content=b"content",
         )
 
@@ -232,7 +232,7 @@ class TestUnknownStatusFromBackend:
         # Mock claim with unknown status
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "SomeNewBackendStatus"},
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,12 @@ class TestConfig:
                 == "http://agentgateway-proxy.agentgateway-system.svc.cluster.local"
             )
 
+    def test_config_with_api_key_requires_api_url(self):
+        """External API key access should fail clearly without an API URL."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="API URL is required"):
+                Config(workspace="test-ws", api_key="test-key")
+
     def test_config_missing_workspace_raises(self):
         """Test that missing workspace raises ValueError."""
         with patch.dict(os.environ, {}, clear=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -61,11 +61,14 @@ class TestConfig:
                 config = Config()
                 assert config.user_id == "kubeflow-user@test.com"
 
-    def test_config_missing_api_url_raises(self):
-        """Test that missing API URL raises ValueError."""
+    def test_config_defaults_to_internal_agent_gateway_url(self):
+        """Test that missing API URL defaults to in-cluster Agent Gateway."""
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="API URL is required"):
-                Config(workspace="test-ws")
+            config = Config(workspace="test-ws")
+            assert (
+                config.api_url
+                == "http://agentgateway-proxy.agentgateway-system.svc.cluster.local"
+            )
 
     def test_config_missing_workspace_raises(self):
         """Test that missing workspace raises ValueError."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,12 +63,20 @@ class TestConfig:
 
     def test_config_defaults_to_internal_agent_gateway_url(self):
         """Test that missing API URL defaults to in-cluster Agent Gateway."""
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(
+            os.environ, {"KUBERNETES_SERVICE_HOST": "10.152.0.1"}, clear=True
+        ):
             config = Config(workspace="test-ws")
             assert (
                 config.api_url
                 == "http://agentgateway-proxy.agentgateway-system.svc.cluster.local"
             )
+
+    def test_config_missing_api_url_outside_cluster_raises(self):
+        """Outside Kubernetes, missing API URL should fail clearly."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="API URL is required"):
+                Config(workspace="test-ws")
 
     def test_config_with_api_key_requires_api_url(self):
         """External API key access should fail clearly without an API URL."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -124,8 +124,7 @@ class TestGetOrigin:
 
     def test_url_with_path(self):
         assert (
-            HttpClient._get_origin("https://example.com/pkui")
-            == "https://example.com"
+            HttpClient._get_origin("https://example.com/pkui") == "https://example.com"
         )
 
     def test_url_with_port(self):
@@ -136,8 +135,7 @@ class TestGetOrigin:
 
     def test_url_with_deep_path(self):
         assert (
-            HttpClient._get_origin("https://example.com/a/b/c")
-            == "https://example.com"
+            HttpClient._get_origin("https://example.com/a/b/c") == "https://example.com"
         )
 
     def test_missing_scheme_raises(self):
@@ -191,16 +189,16 @@ class TestApiKeyBaseUrl:
 
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/pkui/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/pkui/_platform/sandbox/test-ws/sandboxes",
             json={"sandboxes": [], "total": 0},
         )
 
-        response = client.get("/api/namespaces/test-ws/sandboxes")
+        response = client.get("/_platform/sandbox/test-ws/sandboxes")
         assert response == {"sandboxes": [], "total": 0}
 
         request = httpx_mock.get_request()
         assert (
             str(request.url)
-            == "https://test.example.com/pkui/api/namespaces/test-ws/sandboxes"
+            == "https://test.example.com/pkui/_platform/sandbox/test-ws/sandboxes"
         )
         client.close()

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -198,6 +198,23 @@ class TestClientResume:
         assert info.resumed_from_pool is True
         client.close()
 
+    def test_resume_parses_snake_case_pool_resume_hint(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
+            json={"name": "my-sandbox", "phase": "Running", "resumed_from_pool": True},
+        )
+
+        client = SandboxClient(config)
+        info = client.resume("my-sandbox")
+
+        assert info.status == SandboxStatus.RUNNING
+        assert info.resumed_from_pool is True
+        client.close()
+
     def test_resume_conflict_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -318,11 +318,6 @@ class TestSandboxResume:
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Running"},
-        )
 
         sbx = Sandbox.from_pool("python-pool")
         sbx.pause()
@@ -343,7 +338,7 @@ class TestSandboxResume:
             if r.method == "POST"
             and str(r.url).endswith("/sandboxes/sandbox-test/exec")
         ]
-        assert len(get_requests) == 2
+        assert len(get_requests) == 1
         assert not exec_requests
 
         sbx._client.close()

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -54,7 +54,7 @@ def _mock_warmup_probe_success(
     httpx_mock.add_callback(
         _callback,
         method="POST",
-        url=f"{BASE}/api/namespaces/test-ws/sandboxes/{sandbox_name}/exec",
+        url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/{sandbox_name}/exec",
         is_reusable=True,
     )
 
@@ -90,7 +90,7 @@ def _mock_version(httpx_mock: HTTPXMock):
 def _mock_claim(httpx_mock: HTTPXMock, name="sandbox-test", status="Running"):
     httpx_mock.add_response(
         method="POST",
-        url=f"{BASE}/api/namespaces/test-ws/sandboxes/claim",
+        url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/claim",
         json={"name": name, "status": status},
     )
 
@@ -112,7 +112,7 @@ class TestClientPause:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/pause",
             json={"status": "ok"},
         )
 
@@ -129,7 +129,7 @@ class TestClientPause:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/pause",
             status_code=409,
             json={
                 "detail": "Cannot pause sandbox in phase 'Paused'. Only Running sandboxes can be paused."
@@ -149,7 +149,7 @@ class TestClientResume:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
             json={"name": "my-sandbox", "phase": "Pending", "resumedFromPool": False},
         )
 
@@ -171,7 +171,7 @@ class TestClientResume:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
             json={"status": "ok"},
         )
 
@@ -187,7 +187,7 @@ class TestClientResume:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
             json={"name": "my-sandbox", "phase": "Running", "resumedFromPool": True},
         )
 
@@ -202,7 +202,7 @@ class TestClientResume:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
             status_code=409,
             json={
                 "detail": "Cannot resume sandbox in phase 'Running'. Only Paused sandboxes can be resumed."
@@ -223,7 +223,7 @@ class TestSandboxPause:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             json={"status": "ok"},
         )
 
@@ -240,7 +240,7 @@ class TestSandboxPause:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             status_code=409,
             json={
                 "detail": "Cannot pause sandbox in phase 'Paused'. Only Running sandboxes can be paused."
@@ -258,7 +258,7 @@ class TestSandboxPause:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="DELETE",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             status_code=204,
         )
 
@@ -278,13 +278,13 @@ class TestSandboxResume:
         # Pause first
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             json={"status": "ok"},
         )
         # Resume
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Pending", "resumedFromPool": False},
         )
 
@@ -305,17 +305,17 @@ class TestSandboxResume:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             json={"status": "ok"},
         )
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Running", "resumedFromPool": True},
         )
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -350,12 +350,12 @@ class TestSandboxResume:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             json={"status": "ok"},
         )
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -371,7 +371,7 @@ class TestSandboxResume:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
             status_code=409,
             json={
                 "detail": "Cannot resume sandbox in phase 'Running'. Only Paused sandboxes can be resumed."
@@ -394,7 +394,7 @@ class TestWaitUntilReady:
         # GET sandbox returns Running immediately
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
         # wait_until_ready now runs a warmup probe after pod is Running
@@ -415,13 +415,13 @@ class TestWaitUntilReady:
         # First poll: Pending
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Pending"},
         )
         # Second poll: Running
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
         # Warmup probe after Running
@@ -441,17 +441,17 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/pause",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
             json={"status": "ok"},
         )
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/resume",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
             json={"name": "sandbox-test", "phase": "Paused", "resumedFromPool": True},
         )
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
         sbx = Sandbox.from_pool("python-pool")
@@ -478,12 +478,12 @@ class TestWaitUntilReady:
         # First GET: Pending, second GET: Running
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Pending"},
         )
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -521,7 +521,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _probe_callback,
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             is_reusable=True,
         )
 
@@ -542,7 +542,7 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -564,7 +564,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _probe_callback,
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             is_reusable=True,
         )
 
@@ -601,7 +601,7 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -622,7 +622,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _probe_callback,
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             is_reusable=True,
         )
 
@@ -646,7 +646,7 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -670,7 +670,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _probe_callback,
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             is_reusable=True,
         )
 
@@ -699,7 +699,7 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -723,7 +723,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _probe_callback,
             method="POST",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             is_reusable=True,
         )
 
@@ -765,7 +765,7 @@ class TestWaitUntilReady:
         # Always return Pending
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Pending"},
         )
 
@@ -780,7 +780,7 @@ class TestWaitUntilReady:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Failed"},
         )
 
@@ -799,7 +799,7 @@ class TestSandboxPhaseProperty:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Paused"},
         )
 
@@ -813,7 +813,7 @@ class TestSandboxPhaseProperty:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -840,7 +840,7 @@ class TestSandboxConnect:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox",
             json={"name": "my-sandbox", "phase": "Paused"},
         )
 
@@ -854,7 +854,7 @@ class TestSandboxConnect:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes/my-sandbox",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox",
             json={"name": "my-sandbox", "phase": "Running"},
         )
 
@@ -872,7 +872,7 @@ class TestListWithPhaseFilter:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {"name": "sbx-1", "phase": "Running"},
@@ -898,7 +898,7 @@ class TestListWithPhaseFilter:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {"name": "sbx-1", "phase": "Running"},
@@ -914,7 +914,7 @@ class TestListWithPhaseFilter:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/api/namespaces/test-ws/sandboxes",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {"name": "sbx-1", "phase": "Running"},

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -318,6 +318,11 @@ class TestSandboxResume:
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
+            json={"name": "sandbox-test", "phase": "Running"},
+        )
 
         sbx = Sandbox.from_pool("python-pool")
         sbx.pause()
@@ -338,7 +343,7 @@ class TestSandboxResume:
             if r.method == "POST"
             and str(r.url).endswith("/sandboxes/sandbox-test/exec")
         ]
-        assert len(get_requests) == 1
+        assert len(get_requests) == 2
         assert not exec_requests
 
         sbx._client.close()
@@ -454,7 +459,6 @@ class TestWaitUntilReady:
             url=f"{BASE}/api/namespaces/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Running"},
         )
-
         sbx = Sandbox.from_pool("python-pool")
         sbx.pause()
         sbx.resume()

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -215,6 +215,23 @@ class TestClientResume:
         assert info.resumed_from_pool is True
         client.close()
 
+    def test_resume_coalesces_null_pool_resume_hint(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
+            json={"name": "my-sandbox", "phase": "Running", "resumedFromPool": None},
+        )
+
+        client = SandboxClient(config)
+        info = client.resume("my-sandbox")
+
+        assert info.status == SandboxStatus.RUNNING
+        assert info.resumed_from_pool is False
+        client.close()
+
     def test_resume_conflict_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -64,7 +64,7 @@ class TestPoolClientPathRouting:
     """Test that PoolClient picks the right URL prefix."""
 
     def test_internal_path(self, config, httpx_mock: HTTPXMock):
-        """Internal (no api_key) should use /api/namespaces/... prefix."""
+        """Internal (no api_key) should use Agent Gateway platform prefix."""
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
@@ -72,7 +72,7 @@ class TestPoolClientPathRouting:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json={"pools": []},
         )
 
@@ -82,7 +82,7 @@ class TestPoolClientPathRouting:
         requests = httpx_mock.get_requests()
         list_req = [r for r in requests if "sandbox-pools" in str(r.url)]
         assert len(list_req) == 1
-        assert "/api/namespaces/test-ws/sandbox-pools" in str(list_req[0].url)
+        assert "/_platform/sandbox/test-ws/sandbox-pools" in str(list_req[0].url)
         client.close()
 
     def test_api_key_path(self, config_api_key, httpx_mock: HTTPXMock):
@@ -116,7 +116,7 @@ class TestPoolClientCreate:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -163,7 +163,7 @@ class TestPoolClientCreateExtras:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -195,7 +195,7 @@ class TestPoolClientCreateExtras:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -239,7 +239,7 @@ class TestSandboxPoolCreateExtras:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -267,7 +267,7 @@ class TestSandboxPoolCreateExtras:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -302,7 +302,7 @@ class TestPoolClientList:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json={"pools": []},
         )
 
@@ -319,7 +319,7 @@ class TestPoolClientList:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json={
                 "pools": [
                     {
@@ -367,7 +367,7 @@ class TestPoolClientGet:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json={**POOL_RESPONSE, "autoIdleTimeoutSeconds": 1200},
         )
 
@@ -392,7 +392,7 @@ class TestPoolClientDelete:
         )
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             status_code=204,
         )
 
@@ -426,7 +426,7 @@ class TestSandboxPoolCreate:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json=POOL_RESPONSE,
         )
 
@@ -454,7 +454,7 @@ class TestSandboxPoolList:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json={"pools": []},
         )
 
@@ -465,7 +465,7 @@ class TestSandboxPoolList:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools",
             json={
                 "pools": [
                     {
@@ -507,7 +507,7 @@ class TestSandboxPoolGet:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json={**POOL_RESPONSE, "auto_idle_timeout_seconds": 1200},
         )
 
@@ -526,12 +526,12 @@ class TestSandboxPoolDelete:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             status_code=204,
         )
 
@@ -547,12 +547,12 @@ class TestSandboxPoolDelete:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             status_code=204,
         )
 
@@ -569,12 +569,12 @@ class TestSandboxPoolDelete:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             status_code=204,
         )
 
@@ -592,13 +592,13 @@ class TestSandboxPoolRefresh:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
         # Second GET for refresh with updated data
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json={
                 "name": "python-pool",
                 "replicas": 3,
@@ -623,12 +623,12 @@ class TestSandboxPoolRefresh:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json={**POOL_RESPONSE, "autoIdleTimeoutSeconds": 1200},
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
 
@@ -749,7 +749,7 @@ class TestSandboxPoolRepr:
         _mock_version(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandbox-pools/python-pool",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandbox-pools/python-pool",
             json=POOL_RESPONSE,
         )
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -29,7 +29,7 @@ class TestSandboxList:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"sandboxes": [], "total": 0},
         )
 
@@ -47,7 +47,7 @@ class TestSandboxList:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {
@@ -91,7 +91,7 @@ class TestSandboxList:
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={
                 "sandboxes": [
                     {
@@ -128,7 +128,7 @@ class TestSandboxFromPool:
         # Mock claim request
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-abc123", "status": "Running"},
         )
 
@@ -164,7 +164,7 @@ class TestSandboxFromPool:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-abc123", "status": "Running"},
         )
 
@@ -191,7 +191,7 @@ class TestSandboxCreate:
         # Mock create request
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"name": "sandbox-xyz789", "status": "Pending"},
         )
 
@@ -215,7 +215,7 @@ class TestSandboxCreate:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"name": "sandbox-abc", "status": "Pending"},
         )
 
@@ -249,7 +249,7 @@ class TestSandboxCreate:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"name": "sandbox-abc", "status": "Pending"},
         )
 
@@ -299,7 +299,7 @@ class TestSandboxCreate:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
             json={"name": "sandbox-abc", "status": "Pending"},
         )
 
@@ -330,13 +330,13 @@ class TestSandboxRunCode:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock exec
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "42\n",
                 "stderr": "",
@@ -365,12 +365,12 @@ class TestSandboxRunCode:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "Execution timed out after 5 seconds",
@@ -399,12 +399,12 @@ class TestSandboxRunCode:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -434,12 +434,12 @@ class TestSandboxRunCode:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -470,13 +470,13 @@ class TestSandboxRunCode:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # First exec - returns session_id
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -488,7 +488,7 @@ class TestSandboxRunCode:
         # Second exec - should include session_id in request
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "42\n",
                 "stderr": "",
@@ -538,13 +538,13 @@ class TestSandboxRunCode:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # First exec
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -555,7 +555,7 @@ class TestSandboxRunCode:
         # Second exec (after reset)
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -606,13 +606,13 @@ class TestSandboxCommands:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock exec
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "file1.txt\nfile2.txt\n",
                 "stderr": "",
@@ -641,12 +641,12 @@ class TestSandboxCommands:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "[Timeout: no response after 15s]",
@@ -675,12 +675,12 @@ class TestSandboxCommands:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "",
                 "stderr": "",
@@ -709,12 +709,12 @@ class TestSandboxCommands:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "ok\n",
                 "stderr": "warning: timeout option ignored\n",
@@ -743,12 +743,12 @@ class TestSandboxCommands:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/exec",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
             json={
                 "stdout": "ok\n",
                 "stderr": "timeout option ignored\n",
@@ -781,13 +781,13 @@ class TestSandboxFiles:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock file write
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files",
             json={"success": True},
         )
 
@@ -823,12 +823,12 @@ class TestSandboxFiles:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files/batch",
             json={
                 "success": True,
                 "total": 2,
@@ -937,12 +937,12 @@ class TestSandboxFiles:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files/batch",
             json={
                 "success": False,
                 "total": 2,
@@ -989,18 +989,18 @@ class TestSandboxFiles:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/batch",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files/batch",
             status_code=404,
             json={"detail": "Not Found"},
         )
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "status": "Running"},
         )
 
@@ -1022,7 +1022,7 @@ class TestSandboxFiles:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
 
@@ -1047,7 +1047,7 @@ class TestSandboxFiles:
         )
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
 
@@ -1074,13 +1074,13 @@ class TestSandboxFiles:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock file read - uses /files/download?path= endpoint
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files/download?path=%2Fworkspace%2Ftest.txt",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files/download?path=%2Fworkspace%2Ftest.txt",
             content=b"hello world",
         )
 
@@ -1102,13 +1102,13 @@ class TestSandboxFiles:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock file list
         httpx_mock.add_response(
             method="GET",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test/files?path=%2Fworkspace",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test/files?path=%2Fworkspace",
             json={
                 "files": [
                     {"name": "test.txt", "path": "/workspace/test.txt", "size": 11},
@@ -1142,13 +1142,13 @@ class TestSandboxKill:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock delete
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             status_code=204,
         )
 
@@ -1172,13 +1172,13 @@ class TestSandboxContextManager:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
         # Mock delete
         httpx_mock.add_response(
             method="DELETE",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/sandbox-test",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             status_code=204,
         )
 
@@ -1205,7 +1205,7 @@ class TestSandboxRepr:
         # Mock claim
         httpx_mock.add_response(
             method="POST",
-            url="https://test.example.com/api/namespaces/test-ws/sandboxes/claim",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
             json={"name": "sandbox-test", "status": "Running"},
         )
 


### PR DESCRIPTION
## Summary
- Route in-cluster sandbox and sandbox-pool SDK calls through Agent Gateway platform paths
- Default no-API-key usage to the in-cluster Agent Gateway service
- Document notebook usage without API keys

## Testing
- PYTHONPATH=src uv run pytest -q
- Installed the branch in a notebook pod in namespace henrik and verified Sandbox.list, SandboxPool.list, Sandbox.from_pool, run_code, and cleanup