### PR TITLE
fix: Enforce sandbox readiness timeout budget

### DIFF
--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -255,9 +255,10 @@ class SandboxV2Client:
             info.status = SandboxV2Status.PENDING
         return info
 
-    def get(self, name: str) -> SandboxV2Info:
+    def get(self, name: str, request_timeout: float | None = None) -> SandboxV2Info:
         """Get information about a sandbox."""
-        response = self._http.get(self._sandbox_path(name))
+        kwargs = {"timeout": request_timeout} if request_timeout is not None else {}
+        response = self._http.get(self._sandbox_path(name), **kwargs)
         return self._parse_info(response)
 
     def wait_ready(

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -62,9 +62,7 @@ if TYPE_CHECKING:
     from prokube.common.config import Config
 
 
-def _parse_status(
-    status_str: str | None, default: SandboxV2Status
-) -> SandboxV2Status:
+def _parse_status(status_str: str | None, default: SandboxV2Status) -> SandboxV2Status:
     """Parse a phase string to SandboxV2Status, tolerating unknown values."""
     if not status_str:
         return default
@@ -151,9 +149,7 @@ class SandboxV2Client:
         return SandboxV2Info(
             name=response.get("name", ""),
             workspace=response.get("namespace", self._workspace()),
-            status=_parse_status(
-                response.get("phase"), SandboxV2Status.UNKNOWN
-            ),
+            status=_parse_status(response.get("phase"), SandboxV2Status.UNKNOWN),
             image=response.get("image") or None,
             runtime_class=response.get("runtimeClassName"),
             operating_mode=response.get("operatingMode") or None,
@@ -264,7 +260,9 @@ class SandboxV2Client:
         response = self._http.get(self._sandbox_path(name))
         return self._parse_info(response)
 
-    def wait_ready(self, name: str, timeout: int = 30) -> SandboxV2Info:
+    def wait_ready(
+        self, name: str, timeout: int = 30, request_timeout: float | None = None
+    ) -> SandboxV2Info:
         """Server-side long-poll for readiness (single request).
 
         The backend tight-polls committed CR state in-cluster and returns the
@@ -278,8 +276,10 @@ class SandboxV2Client:
         response = self._http.get(
             self._sandbox_sub_path(name, "wait_ready"),
             params={"timeout": timeout},
-            # Give httpx headroom over the server-side long-poll window.
-            timeout=timeout + 10,
+            # Normal direct calls get headroom over the server-side long-poll
+            # window. Callers with an overall deadline can pass request_timeout
+            # to keep this single HTTP request within their remaining budget.
+            timeout=request_timeout if request_timeout is not None else timeout + 10,
         )
         return self._parse_info(response)
 
@@ -362,9 +362,7 @@ class SandboxV2Client:
         )
         return self._parse_pool(response)
 
-    def set_pool_warm_state(
-        self, name: str, warm_state: str
-    ) -> HibernatedPoolInfo:
+    def set_pool_warm_state(self, name: str, warm_state: str) -> HibernatedPoolInfo:
         """Change a pool's ``warmState`` post-create (Hibernated <-> Running).
 
         The fc controller reconciles every member to the new state.
@@ -495,9 +493,7 @@ class SandboxV2Client:
         )
         response = self._http.post(
             self._sandbox_sub_path(name, "exec"),
-            json=request.model_dump(
-                exclude={"session_id", "reset_session"}
-            ),
+            json=request.model_dump(exclude={"session_id", "reset_session"}),
         )
         return CommandResult(
             stdout=response.get("stdout", ""),

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -234,9 +234,9 @@ class SandboxV2:
 
             if use_long_poll and remaining >= 1:
                 try:
-                    # Server long-polls up to its own window; loop here until our
-                    # deadline. Cap each call so a stalled connection still
-                    # rechecks our timeout periodically.
+                    # Server long-polls up to its own window, while the HTTP
+                    # request itself is bounded by the caller's remaining
+                    # readiness budget.
                     info = self._client.wait_ready(
                         self._name,
                         timeout=min(int(remaining), 30),
@@ -266,7 +266,10 @@ class SandboxV2:
                 # Server-side timeout below Running: loop (re-checks deadline).
                 continue
 
-            self.refresh()
+            try:
+                self.refresh(request_timeout=remaining)
+            except httpx.TimeoutException:
+                break
             if self._status == SandboxV2Status.RUNNING:
                 return
             if self._status == SandboxV2Status.FAILED:
@@ -298,10 +301,10 @@ class SandboxV2:
         self._killed = True
         self._client.close()
 
-    def refresh(self) -> None:
+    def refresh(self, request_timeout: float | None = None) -> None:
         """Refresh sandbox information from the API."""
         self._check_not_killed()
-        info = self._client.get(self._name)
+        info = self._client.get(self._name, request_timeout=request_timeout)
         self._status = info.status
         if info.runtime_class is not None:
             self._runtime_class = info.runtime_class

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -230,13 +230,13 @@ class SandboxV2:
             if remaining <= 0:
                 break
 
-            if use_long_poll:
+            if use_long_poll and remaining >= 1:
                 try:
                     # Server long-polls up to its own window; loop here until our
                     # deadline. Cap each call so a stalled connection still
                     # rechecks our timeout periodically.
                     info = self._client.wait_ready(
-                        self._name, timeout=min(int(remaining) + 1, 30)
+                        self._name, timeout=min(int(remaining), 30)
                     )
                 except NotFoundError:
                     # Endpoint absent (older backend) or sandbox genuinely

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import sys
 import time
 
+import httpx
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -236,7 +238,9 @@ class SandboxV2:
                     # deadline. Cap each call so a stalled connection still
                     # rechecks our timeout periodically.
                     info = self._client.wait_ready(
-                        self._name, timeout=min(int(remaining), 30)
+                        self._name,
+                        timeout=min(int(remaining), 30),
+                        request_timeout=remaining,
                     )
                 except NotFoundError:
                     # Endpoint absent (older backend) or sandbox genuinely
@@ -244,6 +248,8 @@ class SandboxV2:
                     # not-found error if the sandbox truly does not exist.
                     use_long_poll = False
                     continue
+                except httpx.TimeoutException:
+                    break
                 self._status = info.status
                 if info.runtime_class is not None:
                     self._runtime_class = info.runtime_class

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -10,6 +10,7 @@ import base64
 import json
 import re
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -198,7 +199,10 @@ class TestCreate:
     def test_facade_create_resources_shorthand(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         sbx = SandboxV2.create(
             image="pk-sandbox-base", resources={"vcpus": 4, "mem_mib": 4096}
@@ -447,7 +451,10 @@ class TestLifecycle:
     def test_wait_until_ready_polls(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         # Prefers the server-side long-poll readiness endpoint, which returns
         # the moment the phase reaches Running.
@@ -463,7 +470,10 @@ class TestLifecycle:
     def test_wait_until_ready_failed_raises(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         httpx_mock.add_response(
             method="GET",
@@ -477,13 +487,99 @@ class TestLifecycle:
     def test_wait_until_ready_timeout(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         # timeout=0 → the deadline has already passed, so no readiness request
         # is issued before it raises.
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
         with pytest.raises(SandboxTimeoutError):
             sbx.wait_until_ready(timeout=0)
+
+    def test_wait_until_ready_pending_uses_single_timeout_budget(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        sent_timeouts: list[int] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        def _pending_callback(request):
+            timeout = int(request.url.params["timeout"])
+            sent_timeouts.append(timeout)
+            elapsed["seconds"] += timeout
+            return httpx.Response(200, json=_sandbox_json(name="sbx", phase="Pending"))
+
+        httpx_mock.add_callback(
+            _pending_callback,
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            is_reusable=True,
+        )
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
+        assert sent_timeouts == [3]
+        assert sbx.status == "Pending"
+        sbx._client.close()
+
+    def test_wait_until_ready_pending_then_running_before_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        sent_timeouts: list[int] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        def _ready_callback(request):
+            timeout = int(request.url.params["timeout"])
+            sent_timeouts.append(timeout)
+            if len(sent_timeouts) == 1:
+                elapsed["seconds"] += 2
+                return httpx.Response(
+                    200, json=_sandbox_json(name="sbx", phase="Pending")
+                )
+            elapsed["seconds"] += 1
+            return httpx.Response(200, json=_sandbox_json(name="sbx", phase="Running"))
+
+        httpx_mock.add_callback(
+            _ready_callback,
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            is_reusable=True,
+        )
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        sbx.wait_until_ready(timeout=5)
+
+        assert sent_timeouts == [5, 3]
+        assert sbx.status == "Running"
+        sbx._client.close()
 
 
 # ---------------------------------------------------------------------------
@@ -552,10 +648,7 @@ class TestApiKeyAndPool:
         try:
             assert sbx.name == "member-1"
             req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
-            assert (
-                str(req.url)
-                == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
-            )
+            assert str(req.url) == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
             body = json.loads(req.content)
             assert body["poolName"] == "python-pool"
         finally:
@@ -890,9 +983,7 @@ class TestGuestDNS:
         assert body["dnsConfig"] == {"options": [{"name": "edns0"}]}
         client.close()
 
-    def test_create_accepts_cr_shaped_dns_dict(
-        self, config, httpx_mock: HTTPXMock
-    ):
+    def test_create_accepts_cr_shaped_dns_dict(self, config, httpx_mock: HTTPXMock):
         """A camelCase CR-shaped dnsConfig dict passes through verbatim."""
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -469,6 +469,29 @@ class TestLifecycle:
         ]
         client.close()
 
+    def test_wait_ready_keeps_default_request_timeout_headroom(
+        self, config, monkeypatch
+    ):
+        client = SandboxV2Client(config)
+        calls = []
+
+        def _get(path, **kwargs):
+            calls.append((path, kwargs))
+            return _sandbox_json(name="sbx", phase="Running")
+
+        monkeypatch.setattr(client._http, "get", _get)
+
+        info = client.wait_ready("sbx", timeout=7)
+
+        assert info.status == SandboxV2Status.RUNNING
+        assert calls == [
+            (
+                "/api/namespaces/test-ns/sandboxv2/sbx/wait_ready",
+                {"params": {"timeout": 7}, "timeout": 17},
+            )
+        ]
+        client.close()
+
     def test_wait_until_ready_polls(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -15,7 +15,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
-from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.common.exceptions import NotFoundError, SandboxError, SandboxTimeoutError
 from prokube.sandboxv2 import SandboxV2, SandboxV2Client, SandboxV2Pool
 from prokube.sandboxv2.models import (
     DNSConfig,
@@ -595,6 +595,45 @@ class TestLifecycle:
             sbx.wait_until_ready(timeout=3)
 
         assert server_timeouts == [3]
+        assert request_timeouts == [3]
+        sbx._client.close()
+
+    def test_wait_until_ready_bounds_local_poll_http_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        request_timeouts: list[float | None] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+
+        def _missing_wait_ready(name, timeout=30, request_timeout=None):
+            raise NotFoundError("wait_ready not available")
+
+        def _timeout_get(name, request_timeout=None):
+            request_timeouts.append(request_timeout)
+            elapsed["seconds"] += request_timeout or 0
+            raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(sbx._client, "wait_ready", _missing_wait_ready)
+        monkeypatch.setattr(sbx._client, "get", _timeout_get)
+
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
         assert request_timeouts == [3]
         sbx._client.close()
 

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -551,6 +551,7 @@ class TestLifecycle:
         )
 
         elapsed = {"seconds": 0.0}
+        server_timeouts: list[int] = []
         request_timeouts: list[float | None] = []
 
         monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
@@ -559,6 +560,7 @@ class TestLifecycle:
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
 
         def _timeout_wait_ready(name, timeout=30, request_timeout=None):
+            server_timeouts.append(timeout)
             request_timeouts.append(request_timeout)
             elapsed["seconds"] += request_timeout or 0
             raise httpx.TimeoutException("timed out")
@@ -571,6 +573,7 @@ class TestLifecycle:
         ):
             sbx.wait_until_ready(timeout=3)
 
+        assert server_timeouts == [3]
         assert request_timeouts == [3]
         sbx._client.close()
 

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -1,6 +1,6 @@
 """Tests for the Sandbox v2 (Firecracker) client and facade.
 
-All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors the v1
+All HTTP is mocked (pytest_httpx or direct client stubs) — no live cluster required. Mirrors the v1
 sandbox tests: covers create (fc-host AND fc-pod), run_code, commands, files,
 pause/resume, get, kill, wait_until_ready polling, the api-key path prefix, and
 claiming a warm-pool member via from_pool.

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -449,7 +449,7 @@ class TestLifecycle:
         client.close()
 
     def test_wait_ready_uses_explicit_request_timeout(self, config, monkeypatch):
-        client = SandboxV2Client(config)
+        client = SandboxV2Client(config, check_version=False)
         calls = []
 
         def _get(path, **kwargs):
@@ -472,7 +472,7 @@ class TestLifecycle:
     def test_wait_ready_keeps_default_request_timeout_headroom(
         self, config, monkeypatch
     ):
-        client = SandboxV2Client(config)
+        client = SandboxV2Client(config, check_version=False)
         calls = []
 
         def _get(path, **kwargs):

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -448,6 +448,27 @@ class TestLifecycle:
         assert info.status == SandboxV2Status.RUNNING
         client.close()
 
+    def test_wait_ready_uses_explicit_request_timeout(self, config, monkeypatch):
+        client = SandboxV2Client(config)
+        calls = []
+
+        def _get(path, **kwargs):
+            calls.append((path, kwargs))
+            return _sandbox_json(name="sbx", phase="Running")
+
+        monkeypatch.setattr(client._http, "get", _get)
+
+        info = client.wait_ready("sbx", timeout=7, request_timeout=2.5)
+
+        assert info.status == SandboxV2Status.RUNNING
+        assert calls == [
+            (
+                "/api/namespaces/test-ns/sandboxv2/sbx/wait_ready",
+                {"params": {"timeout": 7}, "timeout": 2.5},
+            )
+        ]
+        client.close()
+
     def test_wait_until_ready_polls(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -539,6 +539,41 @@ class TestLifecycle:
         assert sbx.status == "Pending"
         sbx._client.close()
 
+    def test_wait_until_ready_bounds_long_poll_http_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        request_timeouts: list[float | None] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+
+        def _timeout_wait_ready(name, timeout=30, request_timeout=None):
+            request_timeouts.append(request_timeout)
+            elapsed["seconds"] += request_timeout or 0
+            raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(sbx._client, "wait_ready", _timeout_wait_ready)
+
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
+        assert request_timeouts == [3]
+        sbx._client.close()
+
     def test_wait_until_ready_pending_then_running_before_timeout(
         self, mock_env, monkeypatch, httpx_mock: HTTPXMock
     ):


### PR DESCRIPTION
## Summary
- Clamp SandboxV2 readiness long-poll requests to the remaining caller timeout budget
- Bound both long-poll and local-poll HTTP request timeouts while wait_until_ready has an overall deadline
- Avoid issuing long-poll requests for the final sub-second slice
- Add coverage for Pending timeout, Pending-to-Running readiness, long-poll request timeout budgeting, local-poll timeout budgeting, and default wait_ready headroom

Closes #36

## Testing
- PYTHONPATH=src python -m pytest tests/test_sandboxv2.py -q
- PYTHONPATH=src python -m pytest -q
- PYTHONPATH=src python -m ruff check src/prokube/sandboxv2/client.py src/prokube/sandboxv2/sandbox.py tests/test_sandboxv2.py
- PYTHONPATH=src python -m ruff format --check src/prokube/sandboxv2/client.py src/prokube/sandboxv2/sandbox.py tests/test_sandboxv2.py

## Notes
- Replaces #37 and #38 because Copilot did not generate a fresh no-comment review after addressed review comments on those PRs.