### PR TITLE
fix: Handle WarmPool claim exhaustion

### DIFF
--- a/src/prokube/common/exceptions.py
+++ b/src/prokube/common/exceptions.py
@@ -4,9 +4,16 @@
 class ProKubeError(Exception):
     """Base exception for all prokube SDK errors."""
 
-    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        reason: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.reason = reason
 
 
 class AuthenticationError(ProKubeError):
@@ -52,6 +59,19 @@ class PoolNotFoundError(SandboxError):
 
 
 class PoolExhaustedError(SandboxError):
-    """Raised when no sandboxes are available in the pool."""
+    """Raised when no warm pool capacity is currently available.
 
-    pass
+    The condition is retryable. If the backend provides a Retry-After header,
+    it is exposed as ``retry_after``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = 429,
+        reason: str | None = "pool_exhausted",
+        retry_after: str | None = None,
+    ) -> None:
+        super().__init__(message, status_code=status_code, reason=reason)
+        self.retry_after = retry_after

--- a/src/prokube/common/http.py
+++ b/src/prokube/common/http.py
@@ -8,7 +8,12 @@ import httpx
 
 from prokube.common.auth import get_auth_headers
 from prokube.common.config import Config
-from prokube.common.exceptions import AuthenticationError, NotFoundError, ProKubeError
+from prokube.common.exceptions import (
+    AuthenticationError,
+    NotFoundError,
+    PoolExhaustedError,
+    ProKubeError,
+)
 
 
 class HttpClient:
@@ -243,11 +248,41 @@ class HttpClient:
                 status_code=404,
             )
         if response.status_code >= 400:
+            error_body: dict[str, Any] = {}
             try:
-                error_detail = response.json().get("detail", response.text)
+                parsed = response.json()
+                if isinstance(parsed, dict):
+                    error_body = parsed
             except Exception:
-                error_detail = response.text
+                pass
+
+            reason = self._extract_error_reason(error_body)
+            if response.status_code == 429 and reason == "pool_exhausted":
+                raise PoolExhaustedError(
+                    "No warm pool capacity is currently available; retry the "
+                    "claim later.",
+                    retry_after=response.headers.get("Retry-After"),
+                )
+
+            error_detail = error_body.get("detail", response.text)
             raise ProKubeError(
                 f"API request failed ({response.status_code}): {error_detail}",
                 status_code=response.status_code,
+                reason=reason,
             )
+
+    @staticmethod
+    def _extract_error_reason(error_body: dict[str, Any]) -> str | None:
+        """Extract a structured error reason from backend error payloads."""
+        for key in ("reason", "error"):
+            value = error_body.get(key)
+            if isinstance(value, str):
+                return value
+
+        detail = error_body.get("detail")
+        if isinstance(detail, dict):
+            for key in ("reason", "error"):
+                value = detail.get(key)
+                if isinstance(value, str):
+                    return value
+        return None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
+from prokube.common.exceptions import PoolExhaustedError
 from prokube.sandbox.client import SandboxClient, _parse_status
 from prokube.sandbox.models import SandboxStatus
 
@@ -140,6 +141,32 @@ class TestListSandboxes:
         assert body["poolName"] == "python-pool"
         assert body["autoIdleTimeoutSeconds"] == 900
         assert info.auto_idle_timeout_seconds == 900
+        client.close()
+
+    def test_claim_pool_exhausted_raises_retryable_error(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """claim_from_pool exposes 429 pool_exhausted distinctly."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "10"},
+            json={"error": "pool_exhausted"},
+        )
+
+        client = SandboxClient(config)
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            client.claim_from_pool("python-pool")
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "10"
         client.close()
 
     def test_list_with_status_field(self, config, httpx_mock: HTTPXMock):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -64,3 +64,10 @@ class TestExceptions:
         """Test PoolExhaustedError inherits from SandboxError."""
         error = PoolExhaustedError("pool exhausted")
         assert isinstance(error, SandboxError)
+
+    def test_pool_exhausted_preserves_retry_metadata(self):
+        """PoolExhaustedError exposes structured retry metadata."""
+        error = PoolExhaustedError("pool exhausted", retry_after="15")
+        assert error.status_code == 429
+        assert error.reason == "pool_exhausted"
+        assert error.retry_after == "15"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
-from prokube.common.exceptions import NotFoundError, ProKubeError
+from prokube.common.exceptions import NotFoundError, PoolExhaustedError, ProKubeError
 from prokube.common.http import HttpClient
 
 
@@ -99,6 +99,42 @@ class TestHttpClient:
 
         with pytest.raises(ProKubeError, match="Internal server error"):
             http_client.get("/api/error")
+
+    def test_429_pool_exhausted_raises_pool_exhausted_error(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """Structured pool_exhausted responses are retryable typed errors."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "5"},
+            json={"reason": "pool_exhausted", "error": "pool_exhausted"},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            http_client.post("/api/sandboxes/claim", json={"poolName": "python-pool"})
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "5"
+        assert "No warm pool capacity" in str(exc_info.value)
+
+    def test_detail_429_pool_exhausted_raises_pool_exhausted_error(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """The backend may nest the structured reason under detail."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/sandboxes/claim",
+            status_code=429,
+            json={"detail": {"reason": "pool_exhausted"}},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            http_client.post("/api/sandboxes/claim", json={"poolName": "python-pool"})
+
+        assert exc_info.value.retry_after is None
 
     def test_auth_headers_included(
         self, http_client: HttpClient, httpx_mock: HTTPXMock

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,7 +5,7 @@ import base64
 import pytest
 from pytest_httpx import HTTPXMock
 
-from prokube.common.exceptions import SandboxError
+from prokube.common.exceptions import PoolExhaustedError, SandboxError
 from prokube.sandbox import Sandbox
 
 
@@ -175,6 +175,28 @@ class TestSandboxFromPool:
         assert body["autoIdleTimeoutSeconds"] == 900
         assert sbx.auto_idle_timeout_seconds == 900
         sbx._client.close()
+
+    def test_from_pool_exposes_pool_exhaustion(self, mock_env, httpx_mock: HTTPXMock):
+        """from_pool preserves retryable 429 pool_exhausted responses."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "30"},
+            json={"reason": "pool_exhausted"},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            Sandbox.from_pool("python-pool")
+
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "30"
+        assert "No warm pool capacity" in str(exc_info.value)
 
 
 class TestSandboxCreate:


### PR DESCRIPTION
## Summary
- Map structured HTTP 429 `pool_exhausted` responses to `PoolExhaustedError`
- Preserve `Retry-After` on pool exhaustion errors
- Add claim/from_pool tests for retryable pool exhaustion while preserving successful claim coverage

Closes #40

## Testing
- `uv run --extra dev ruff check src/prokube/common/exceptions.py src/prokube/common/http.py tests/test_http.py tests/test_client.py tests/test_sandbox.py tests/test_exceptions.py`
- `uv run --extra dev python -m pytest tests/test_http.py tests/test_client.py tests/test_sandbox.py tests/test_exceptions.py -v`