### PR TITLE
docs: Use valid sandbox image examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ with Sandbox.from_pool("python-pool") as sbx:
 sandboxes. It mirrors the v1 `Sandbox` surface (`run_code` / `commands` / `files` /
 `pause` / `resume` / `kill`), adapted for v2: pick a `runtime_class`
 (`fc-host` — a real microVM, default — or `fc-pod`), sandboxes are addressed by
-`namespace` (the v1 `workspace`), and there is **no warm pool** (`from_pool`
-raises `NotImplementedError`).
+`namespace` (the v1 `workspace`), and the warm pool is a
+**FirecrackerHibernatedPool** (`SandboxV2Pool` + `SandboxV2.from_pool`), which
+claims a pre-hibernated member via a fast VM resume rather than a cold boot.
 
 ```python
 from prokube.sandboxv2 import SandboxV2
@@ -96,6 +97,29 @@ sbx.pause()
 sbx.resume()
 
 sbx.kill()
+```
+
+Warm pool (FirecrackerHibernatedPool) — maintain pre-hibernated members and
+claim one via a fast VM resume instead of a cold boot:
+
+```python
+from prokube.sandboxv2 import SandboxV2, SandboxV2Pool
+
+# Create a pool of 3 pre-hibernated fc-host members (pools are fc-host only)
+pool = SandboxV2Pool.create(
+    name="python-pool",
+    size=3,
+    image="pk-sandbox-base",
+    resources={"vcpus": 2, "mem_mib": 2048},
+    namespace="my-namespace",
+)
+
+# Claim a warm member (fast resume ~1.4s); the controller refills the pool
+sbx = SandboxV2.from_pool("python-pool", namespace="my-namespace")
+sbx.wait_until_ready()
+print(sbx.run_code("print('hi')").stdout)
+
+pool.delete()
 ```
 
 `SandboxV2` reuses the same `x-api-key` auth, HTTP client, and configuration as

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ sandboxes. It mirrors the v1 `Sandbox` surface (`run_code` / `commands` / `files
 `pause` / `resume` / `kill`), adapted for v2: pick a `runtime_class`
 (`fc-host` — a real microVM, default — or `fc-pod`), sandboxes are addressed by
 `namespace` (the v1 `workspace`), and the warm pool is a
-**FirecrackerHibernatedPool** (`SandboxV2Pool` + `SandboxV2.from_pool`), which
-claims a pre-hibernated member via a fast VM resume rather than a cold boot.
+**FirecrackerPool** (`SandboxV2Pool` + `SandboxV2.from_pool`), which claims a
+warm member via a fast VM resume rather than a cold boot. A pool's `warm_state`
+(`"Hibernated"`, default, or `"Running"`) sets whether members are kept
+pre-snapshotted or hot.
 
 ```python
 from prokube.sandboxv2 import SandboxV2
@@ -99,20 +101,24 @@ sbx.resume()
 sbx.kill()
 ```
 
-Warm pool (FirecrackerHibernatedPool) — maintain pre-hibernated members and
-claim one via a fast VM resume instead of a cold boot:
+Warm pool (FirecrackerPool) — maintain warm members and claim one via a fast VM
+resume instead of a cold boot:
 
 ```python
 from prokube.sandboxv2 import SandboxV2, SandboxV2Pool
 
-# Create a pool of 3 pre-hibernated fc-host members (pools are fc-host only)
+# Create a pool of 3 warm fc-host members (pools are fc-host only)
 pool = SandboxV2Pool.create(
     name="python-pool",
     size=3,
     image="pk-sandbox-base",
+    warm_state="Hibernated",            # or "Running" to keep members hot
     resources={"vcpus": 2, "mem_mib": 2048},
     namespace="my-namespace",
 )
+
+# Flip the pool between hibernated and hot at any time
+pool.set_warm_state("Running")
 
 # Claim a warm member (fast resume ~1.4s); the controller refills the pool
 sbx = SandboxV2.from_pool("python-pool", namespace="my-namespace")

--- a/README.md
+++ b/README.md
@@ -63,6 +63,44 @@ with Sandbox.from_pool("python-pool") as sbx:
 # Sandbox is automatically cleaned up
 ```
 
+### Sandboxes v2 (Firecracker)
+
+`prokube.sandboxv2.SandboxV2` is a parallel client for Firecracker-backed microVM
+sandboxes. It mirrors the v1 `Sandbox` surface (`run_code` / `commands` / `files` /
+`pause` / `resume` / `kill`), adapted for v2: pick a `runtime_class`
+(`fc-host` — a real microVM, default — or `fc-pod`), sandboxes are addressed by
+`namespace` (the v1 `workspace`), and there is **no warm pool** (`from_pool`
+raises `NotImplementedError`).
+
+```python
+from prokube.sandboxv2 import SandboxV2
+
+# Create a Firecracker microVM (cold start)
+sbx = SandboxV2.create(
+    image="pk-sandbox-base",
+    runtime_class="fc-host",            # or "fc-pod"
+    resources={"vcpus": 2, "mem_mib": 2048},
+    egress=False,                       # default: isolated (no outbound network)
+    namespace="my-namespace",
+)
+sbx.wait_until_ready()                  # polls until phase == "Running"
+
+# Stateful code, shell commands and files work exactly like v1
+print(sbx.run_code("print(2 + 2)").stdout)
+sbx.commands.run("pip install numpy")
+sbx.files.write("/workspace/x.txt", "hello")
+print(sbx.files.read("/workspace/x.txt").decode())
+
+# Pause == native VM snapshot; resume == restore
+sbx.pause()
+sbx.resume()
+
+sbx.kill()
+```
+
+`SandboxV2` reuses the same `x-api-key` auth, HTTP client, and configuration as
+v1, so the environment variables below apply unchanged.
+
 ## Configuration
 
 Configuration can be provided via environment variables or explicitly:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ from prokube.sandbox import Sandbox
 sbx = Sandbox.from_pool("python-pool")
 
 # Or create directly (cold start, ~10-30s)
-sbx = Sandbox.create(image="pk-sandbox:python-datascience")
+sbx = Sandbox.create(
+    image="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026"
+)
 
 # Execute code (stateful - variables persist between calls)
 sbx.run_code("import pandas as pd")

--- a/sandbox-v2-cutover-runbook.md
+++ b/sandbox-v2-cutover-runbook.md
@@ -1,0 +1,151 @@
+# SandboxV2 backend cutover runbook (strangler-fig Phase 2)
+
+Move the SandboxV2 (Firecracker) backend out of the **pkui monolith** into the
+standalone **`fc-sandbox-api`** service, with **zero consumer code change** via
+**path-based ingress reroute**.
+
+This runbook is the ordered, reversible sequence the orchestrator executes
+**after** Phase 1's `fc-sandbox-api` is deployed and live-verified. Consumer-side
+prep (SDK guard test, frontend note, pkui backend removal) is already staged as
+un-merged branches (see "Staged branches" below). **Do not merge or switch
+ingress before the new service is live** — reversing the order is a production
+outage.
+
+> Authoritative service coordinates (Service DNS, exact ingress annotations)
+> come from Phase 1's `sandbox-api/CUTOVER.md`. As of this writing Phase 1 has
+> published only `manifests/rbac.yaml`. Known so far:
+> - ServiceAccount / namespace: `fc-sandbox-api` in `default`
+> - Container port: **8083**
+> - Expected Service: `fc-sandbox-api.default.svc.cluster.local:8083` (confirm)
+> Fill the `<...>` placeholders from CUTOVER.md before executing.
+
+---
+
+## The contract being rerouted
+
+`fc-sandbox-api` serves the **byte-identical** route surface pkui exposes today
+(Phase 1 mounts the same routers at the same prefixes). Two path families:
+
+**A. External API-key routes (prokube-sdk, api-key auth)** — clean top-level
+prefix, trivial to reroute:
+
+```
+/sandboxv2/{ns}/sandboxes                         (list, create)
+/sandboxv2/{ns}/sandboxes/claim                   (claim warm member)
+/sandboxv2/{ns}/sandboxes/{name}                  (get, delete)
+/sandboxv2/{ns}/sandboxes/{name}/wait_ready
+/sandboxv2/{ns}/sandboxes/{name}/pause | resume
+/sandboxv2/{ns}/sandboxes/{name}/exec
+/sandboxv2/{ns}/sandboxes/{name}/files | files/batch | files/download
+```
+
+**B. Internal UI routes (pkui frontend + in-cluster SDK, header auth)** — live
+**under `/api`, interleaved with pkui's other `/api` routes**. The namespace is a
+**mid-path variable**, so these need a **regex** ingress rule, not a simple
+prefix:
+
+```
+/api/namespaces/{ns}/sandboxv2
+/api/namespaces/{ns}/sandboxv2/{name}[/pause|/resume|/exec|/events|/terminal(WS)]
+/api/namespaces/{ns}/sandboxv2/{name}/files[/batch|/download]
+/api/namespaces/{ns}/sandboxv2-pools[/{name}[/claim]]
+/api/namespaces/{ns}/sandboxv2-nodes
+/api/namespaces/{ns}/sandboxv2-storageclasses
+/api/namespaces/{ns}/sandboxv2-pvcs
+/api/namespaces/{ns}/sandboxv2-image-presets
+```
+
+> **Do NOT** reroute all of `/api/*` — that path also serves v1 sandbox, pods,
+> volumes, etc., which must stay on pkui. Match only `sandboxv2` after the
+> namespace segment, e.g. nginx regex
+> `^/api/namespaces/[^/]+/sandboxv2` (covers both `/sandboxv2` and
+> `/sandboxv2-*` because `-pools` etc. share the `sandboxv2` stem). The
+> `/api/namespaces/{ns}/sandboxv2/{name}/terminal` route is a **WebSocket** —
+> keep the WS-upgrade annotations on that ingress.
+
+Family A reroute = one rule `^/sandboxv2/` → `fc-sandbox-api`.
+
+### Consumer code-change assessment (evidence)
+
+- **prokube-sdk**: same host, path-routed. api-key mode strips `api_url` to its
+  origin and calls top-level `/sandboxv2/...`; in-cluster mode calls
+  `/api/namespaces/{ns}/sandboxv2...` on Agent Gateway. Neither hardcodes a
+  pkui-specific host. **Zero code change.** (Guard: `tests/test_sandboxv2_path_contract.py`.)
+- **pkui frontend**: all v2 calls go through `apiFetch`+`namespacePath`, which
+  build **same-origin relative** `${basePath}/api/namespaces/{ns}/sandboxv2...`
+  (and a same-host WS for the terminal). No pkui backend base URL is hardcoded.
+  **Zero code change.** The v2 frontend module *stays in pkui* and is served by
+  `fc-sandbox-api` via the reroute.
+- **SDK version check**: in-cluster only, hits generic `/api/version` (NOT a
+  sandboxv2 path, so it stays on pkui) and is wrapped in try/except (warn-only).
+  Not a blocker. `fc-sandbox-api` need not serve `/api/version`.
+
+---
+
+## Staged branches (all un-merged)
+
+| Repo | Branch | Contents | Merge when |
+|------|--------|----------|-----------|
+| prokube-sdk | `feat/sandboxv2-cutover-prep` | this runbook + path-contract guard test | step (d), optional |
+| pkui (worktree `pkui-sandboxv2`) | `docs/sandboxv2-frontend-cutover-note` | comment in `frontend/.../sandboxv2/api.ts` noting ingress reroute; **no functional change** | step (d), optional |
+| pkui (worktree `pkui-sandboxv2`) | `chore/pkui-remove-sandboxv2-backend` | removes pkui-backend v2 (module + external route + wiring); **keeps v1 and the v2 frontend** | step (e), **LAST** |
+
+---
+
+## Ordered cutover steps (each with rollback)
+
+### (a) Phase 1 service deployed + verified
+- Apply `fc-sandbox-api` SA/RBAC/Deployment/Service (+ its own ingress manifest,
+  owned by Phase 1). Confirm `GET /health` and `/api/health` return healthy and
+  the pod is Ready.
+- Smoke one route directly against the Service (port-forward or in-cluster curl),
+  e.g. `GET /api/namespaces/<ns>/sandboxv2` and `GET /sandboxv2/<ns>/sandboxes`.
+- **Rollback**: delete the new Deployment/Service. No consumer impact — nothing
+  points at it yet.
+
+### (b) Ingress switch `/sandboxv2/*` and `/api/namespaces/*/sandboxv2*` → new Service
+- Add the two reroute rules (Family A prefix + Family B regex, WS annotations on
+  the terminal path) pointing at `<fc-sandbox-api Service>`. Higher priority than
+  pkui's catch-all `/api`.
+- pkui still serves these paths too (removal is step (e)), so this is a pure
+  traffic move — instantly reversible.
+- **Rollback**: remove the two reroute rules; traffic falls back to pkui, which
+  still serves v2. **This is the single most important rollback and stays valid
+  until step (e) merges.**
+
+### (c) Verify SDK + frontend against the new service
+- **SDK (external)**: with a real api-key + `PROKUBE_API_URL=<gateway host>`, run
+  create → wait_ready → exec → files → pause → resume → delete, and a pool
+  claim. Confirm requests land on `fc-sandbox-api` (check its logs).
+- **SDK (in-cluster)**: from an in-cluster pod against Agent Gateway, same flow.
+- **Frontend**: load the SandboxesV2 + Pools pages, create/exec/pause/resume, and
+  open the ttyd **terminal** (WebSocket) — verify all hit `fc-sandbox-api`.
+- **Rollback**: same as (b) — pull the reroute rules.
+
+### (d) Merge SDK / frontend prep branches (optional, low-risk)
+- Merge `feat/sandboxv2-cutover-prep` (SDK) and
+  `docs/sandboxv2-frontend-cutover-note` (pkui). Neither changes runtime
+  behavior; they document the cutover and guard the path contract. Safe to merge
+  any time after (c), or to skip.
+- **Rollback**: revert the merge(s). No runtime effect.
+
+### (e) Merge pkui v2-removal **LAST**
+- Only after (c) is green and has soaked. Merge
+  `chore/pkui-remove-sandboxv2-backend` and redeploy pkui. This removes pkui's
+  ability to serve v2 — **after this, the ingress reroute (b) is the only path
+  to v2 and step (b) rollback no longer works.**
+- Verify post-deploy: pkui starts clean, v1 sandbox + all other modules work,
+  and v2 still works end-to-end (now exclusively via `fc-sandbox-api`).
+- **Rollback**: revert the removal merge and redeploy pkui (restores pkui's v2
+  serving), OR keep the reroute and fix forward. Because this is the
+  irreversible-in-practice step, treat (c) soak as the gate.
+
+---
+
+## Pre-flight checklist
+- [ ] Phase 1 `CUTOVER.md` read; Service DNS + ingress annotations filled into `<...>`.
+- [ ] New service Ready; `/health` + a direct route smoke green (a).
+- [ ] Reroute rules added, both families, WS annotations on terminal (b).
+- [ ] SDK external + in-cluster + frontend (incl. terminal) verified on new service (c).
+- [ ] Soak window observed with no v2 errors.
+- [ ] `chore/pkui-remove-sandboxv2-backend` merged + pkui redeployed; v1 + v2 verified (e).

--- a/src/prokube/common/exceptions.py
+++ b/src/prokube/common/exceptions.py
@@ -4,9 +4,16 @@
 class ProKubeError(Exception):
     """Base exception for all prokube SDK errors."""
 
-    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        reason: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.reason = reason
 
 
 class AuthenticationError(ProKubeError):
@@ -52,6 +59,19 @@ class PoolNotFoundError(SandboxError):
 
 
 class PoolExhaustedError(SandboxError):
-    """Raised when no sandboxes are available in the pool."""
+    """Raised when no warm pool capacity is currently available.
 
-    pass
+    The condition is retryable. If the backend provides a Retry-After header,
+    it is exposed as ``retry_after``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = 429,
+        reason: str | None = "pool_exhausted",
+        retry_after: str | None = None,
+    ) -> None:
+        super().__init__(message, status_code=status_code, reason=reason)
+        self.retry_after = retry_after

--- a/src/prokube/common/http.py
+++ b/src/prokube/common/http.py
@@ -8,7 +8,12 @@ import httpx
 
 from prokube.common.auth import get_auth_headers
 from prokube.common.config import Config
-from prokube.common.exceptions import AuthenticationError, NotFoundError, ProKubeError
+from prokube.common.exceptions import (
+    AuthenticationError,
+    NotFoundError,
+    PoolExhaustedError,
+    ProKubeError,
+)
 
 
 class HttpClient:
@@ -243,11 +248,41 @@ class HttpClient:
                 status_code=404,
             )
         if response.status_code >= 400:
+            error_body: dict[str, Any] = {}
             try:
-                error_detail = response.json().get("detail", response.text)
+                parsed = response.json()
+                if isinstance(parsed, dict):
+                    error_body = parsed
             except Exception:
-                error_detail = response.text
+                pass
+
+            reason = self._extract_error_reason(error_body)
+            if response.status_code == 429 and reason == "pool_exhausted":
+                raise PoolExhaustedError(
+                    "No warm pool capacity is currently available; retry the "
+                    "claim later.",
+                    retry_after=response.headers.get("Retry-After"),
+                )
+
+            error_detail = error_body.get("detail", response.text)
             raise ProKubeError(
                 f"API request failed ({response.status_code}): {error_detail}",
                 status_code=response.status_code,
+                reason=reason,
             )
+
+    @staticmethod
+    def _extract_error_reason(error_body: dict[str, Any]) -> str | None:
+        """Extract a structured error reason from backend error payloads."""
+        for key in ("reason", "error"):
+            value = error_body.get(key)
+            if isinstance(value, str):
+                return value
+
+        detail = error_body.get("detail")
+        if isinstance(detail, dict):
+            for key in ("reason", "error"):
+                value = detail.get(key)
+                if isinstance(value, str):
+                    return value
+        return None

--- a/src/prokube/common/http.py
+++ b/src/prokube/common/http.py
@@ -117,6 +117,24 @@ class HttpClient:
         response = self.client.post(self._normalize_path(path), **kwargs)
         return self._handle_response(response)
 
+    def patch(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Make a PATCH request.
+
+        Args:
+            path: API path (will be joined with base_url).
+            **kwargs: Additional arguments to pass to httpx.
+
+        Returns:
+            JSON response as dictionary.
+
+        Raises:
+            AuthenticationError: If authentication fails (401/403).
+            NotFoundError: If resource is not found (404).
+            ProKubeError: For other HTTP errors.
+        """
+        response = self.client.patch(self._normalize_path(path), **kwargs)
+        return self._handle_response(response)
+
     def delete(self, path: str, **kwargs: Any) -> dict[str, Any] | None:
         """Make a DELETE request.
 

--- a/src/prokube/sandbox/pool.py
+++ b/src/prokube/sandbox/pool.py
@@ -22,7 +22,7 @@ class SandboxPool:
     Example:
         >>> pool = SandboxPool.create(
         ...     name="python-pool",
-        ...     image="pk-sandbox-base:latest",
+        ...     image="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026",
         ...     pool_size=3,
         ...     cpu="2",
         ...     memory="4Gi",
@@ -211,7 +211,7 @@ class SandboxPool:
         Example:
             >>> pool = SandboxPool.create(
             ...     name="my-pool",
-            ...     image="pk-sandbox-base:pr-5",
+            ...     image="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026",
             ...     pool_size=3,
             ...     cpu="2",
             ...     memory="4Gi",

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -606,7 +606,7 @@ class Sandbox:
 
         Example:
             >>> sbx = Sandbox.create(
-            ...     image="pk-sandbox:python-datascience",
+            ...     image="europe-west3-docker.pkg.dev/prokube-internal/prokube-customer/pk-sandbox-base:v14-05-2026",
             ...     cpu="2",
             ...     memory="4Gi",
             ...     allow_internet_access=True,

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -4,7 +4,7 @@ A parallel client to :mod:`prokube.sandbox`, targeting the Firecracker-backed
 ``sandboxv2`` endpoints. Reuses ``prokube.common`` (auth, http, config,
 exceptions) verbatim and mirrors the v1 public surface, adapted for microVMs
 (``runtime_class`` fc-host/fc-pod, same ``workspace`` param as v1, warm pool via
-FirecrackerHibernatedPool).
+FirecrackerPool with a ``warm_state`` Hibernated/Running knob).
 """
 
 from prokube.sandboxv2.client import SandboxV2Client

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -8,7 +8,27 @@ FirecrackerPool with a ``warm_state`` Hibernated/Running knob).
 """
 
 from prokube.sandboxv2.client import SandboxV2Client
+from prokube.sandboxv2.models import (
+    ExecAction,
+    HTTPGetAction,
+    HTTPHeader,
+    Lifecycle,
+    LifecycleHandler,
+    Probe,
+    TCPSocketAction,
+)
 from prokube.sandboxv2.pool import SandboxV2Pool
 from prokube.sandboxv2.sandbox import SandboxV2
 
-__all__ = ["SandboxV2", "SandboxV2Client", "SandboxV2Pool"]
+__all__ = [
+    "SandboxV2",
+    "SandboxV2Client",
+    "SandboxV2Pool",
+    "Probe",
+    "Lifecycle",
+    "LifecycleHandler",
+    "HTTPGetAction",
+    "HTTPHeader",
+    "TCPSocketAction",
+    "ExecAction",
+]

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -3,8 +3,8 @@
 A parallel client to :mod:`prokube.sandbox`, targeting the Firecracker-backed
 ``sandboxv2`` endpoints. Reuses ``prokube.common`` (auth, http, config,
 exceptions) verbatim and mirrors the v1 public surface, adapted for microVMs
-(``runtime_class`` fc-host/fc-pod, ``namespace`` instead of ``workspace``, no
-warm pool via FirecrackerHibernatedPool).
+(``runtime_class`` fc-host/fc-pod, same ``workspace`` param as v1, warm pool via
+FirecrackerHibernatedPool).
 """
 
 from prokube.sandboxv2.client import SandboxV2Client

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -9,6 +9,8 @@ FirecrackerPool with a ``warm_state`` Hibernated/Running knob).
 
 from prokube.sandboxv2.client import SandboxV2Client
 from prokube.sandboxv2.models import (
+    DNSConfig,
+    DNSConfigOption,
     ExecAction,
     HTTPGetAction,
     HTTPHeader,
@@ -31,4 +33,6 @@ __all__ = [
     "HTTPHeader",
     "TCPSocketAction",
     "ExecAction",
+    "DNSConfig",
+    "DNSConfigOption",
 ]

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -1,0 +1,13 @@
+"""Sandbox v2 (Firecracker) module for the prokube SDK.
+
+A parallel client to :mod:`prokube.sandbox`, targeting the Firecracker-backed
+``sandboxv2`` endpoints. Reuses ``prokube.common`` (auth, http, config,
+exceptions) verbatim and mirrors the v1 public surface, adapted for microVMs
+(``runtime_class`` fc-host/fc-pod, ``namespace`` instead of ``workspace``, no
+warm pool).
+"""
+
+from prokube.sandboxv2.client import SandboxV2Client
+from prokube.sandboxv2.sandbox import SandboxV2
+
+__all__ = ["SandboxV2", "SandboxV2Client"]

--- a/src/prokube/sandboxv2/__init__.py
+++ b/src/prokube/sandboxv2/__init__.py
@@ -4,10 +4,11 @@ A parallel client to :mod:`prokube.sandbox`, targeting the Firecracker-backed
 ``sandboxv2`` endpoints. Reuses ``prokube.common`` (auth, http, config,
 exceptions) verbatim and mirrors the v1 public surface, adapted for microVMs
 (``runtime_class`` fc-host/fc-pod, ``namespace`` instead of ``workspace``, no
-warm pool).
+warm pool via FirecrackerHibernatedPool).
 """
 
 from prokube.sandboxv2.client import SandboxV2Client
+from prokube.sandboxv2.pool import SandboxV2Pool
 from prokube.sandboxv2.sandbox import SandboxV2
 
-__all__ = ["SandboxV2", "SandboxV2Client"]
+__all__ = ["SandboxV2", "SandboxV2Client", "SandboxV2Pool"]

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -1,0 +1,366 @@
+"""HTTP client for Sandbox v2 (Firecracker) API operations.
+
+Reuses ``prokube.common`` verbatim (same ``x-api-key`` auth, http client,
+config, exceptions) and the v1 execd result models. Only the path space and the
+create/get/pause/resume lifecycle differ from v1:
+
+* v1 paths:  ``/sandbox/{ws}/sandboxes/...`` (external) or
+  ``/_platform/sandbox/{ws}/sandboxes/...`` (in-cluster).
+* v2 paths:  ``/api/namespaces/{ns}/sandboxv2/...`` — the FastAPI router is
+  mounted at ``/api`` and is namespaced. v1's ``workspace`` concept maps 1:1 to
+  the v2 ``namespace``.
+
+The exposed method surface (``exec_code`` / ``exec_command`` / ``write_file`` /
+``read_file`` / ``list_files`` / ``write_files_batch``) matches v1's
+``SandboxClient`` exactly so the v1 ``CodeRunner`` / ``CommandRunner`` /
+``FileManager`` helpers can be reused unmodified.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from prokube.common.compat import check_backend_compatibility
+from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
+from prokube.common.http import HttpClient
+from prokube.sandbox.client import _parse_batch_file_write_response
+from prokube.sandbox.models import (
+    BatchFileWriteRequest,
+    BatchFileWriteResponse,
+    FileWriteRequest,
+)
+from prokube.sandboxv2.models import (
+    CodeResult,
+    CommandResult,
+    CreateSandboxV2Request,
+    ExecV2Request,
+    FileInfo,
+    SandboxV2Info,
+    SandboxV2Status,
+    UploadFileV2Request,
+)
+
+if TYPE_CHECKING:
+    from prokube.common.config import Config
+
+
+def _parse_status(
+    status_str: str | None, default: SandboxV2Status
+) -> SandboxV2Status:
+    """Parse a phase string to SandboxV2Status, tolerating unknown values."""
+    if not status_str:
+        return default
+    try:
+        return SandboxV2Status(status_str)
+    except ValueError:
+        return SandboxV2Status.UNKNOWN
+
+
+class SandboxV2Client:
+    """Client for Sandbox v2 (Firecracker) API operations."""
+
+    def __init__(self, config: Config, check_version: bool = True) -> None:
+        """Initialize the v2 sandbox client.
+
+        Args:
+            config: SDK configuration. ``config.workspace`` is used as the v2
+                namespace.
+            check_version: Whether to check backend version compatibility.
+        """
+        self.config = config
+        self._http = HttpClient(config)
+
+        if check_version:
+            check_backend_compatibility(self._http)
+
+    def close(self) -> None:
+        """Close the client."""
+        self._http.close()
+
+    # -- path helpers ---------------------------------------------------------
+
+    def _namespace(self) -> str:
+        return self.config.workspace
+
+    def _prefix(self) -> str:
+        """Path prefix to prepend under API-key (external) access.
+
+        The shared ``HttpClient`` strips ``api_url`` down to its origin for
+        API-key access (v1's external ``/sandbox/*`` routes are top-level). The
+        v2 routes, by contrast, live under the app's own path prefix
+        (e.g. ``/pkui/api/namespaces/...``), so when using an API key we must
+        re-attach the configured path prefix. For in-cluster access the full
+        ``api_url`` (prefix included) is preserved by ``HttpClient`` already, so
+        no prefix is added here.
+        """
+        if self.config.use_api_key:
+            return urlparse(self.config.api_url).path.rstrip("/")
+        return ""
+
+    def _collection_path(self) -> str:
+        return f"{self._prefix()}/api/namespaces/{self._namespace()}/sandboxv2"
+
+    def _sandbox_path(self, name: str) -> str:
+        return f"{self._collection_path()}/{name}"
+
+    def _sandbox_sub_path(self, name: str, sub: str) -> str:
+        return f"{self._sandbox_path(name)}/{sub}"
+
+    # -- parsing --------------------------------------------------------------
+
+    def _parse_info(self, response: dict[str, object]) -> SandboxV2Info:
+        return SandboxV2Info(
+            name=response.get("name", ""),
+            namespace=response.get("namespace", self._namespace()),
+            status=_parse_status(
+                response.get("phase"), SandboxV2Status.UNKNOWN
+            ),
+            image=response.get("image") or None,
+            runtime_class=response.get("runtimeClassName"),
+            operating_mode=response.get("operatingMode") or None,
+            node=response.get("node"),
+            endpoint=response.get("endpoint"),
+            terminal_enabled=bool(response.get("terminalEnabled", True)),
+            message=response.get("message"),
+            created_at=response.get("createdAt"),
+        )
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def create(
+        self,
+        image: str | None = None,
+        name: str | None = None,
+        runtime_class: str = "fc-host",
+        vcpus: int | None = None,
+        mem_mib: int | None = None,
+        egress: bool = False,
+        terminal: bool = True,
+        volumes: list[dict[str, object]] | None = None,
+        volume_mounts: list[dict[str, object]] | None = None,
+        image_pull_secrets: list[str] | None = None,
+        workspace_size: str | None = None,
+        target_node: str | None = None,
+        operating_mode: str | None = None,
+        manifest: dict[str, object] | None = None,
+    ) -> SandboxV2Info:
+        """Create a new Firecracker sandbox.
+
+        Returns as soon as the CR is created; the controller drives
+        Pending -> Running asynchronously (poll via :meth:`get`).
+        """
+        if name is None:
+            name = f"sandbox-{uuid.uuid4().hex[:8]}"
+
+        request = CreateSandboxV2Request(
+            name=name,
+            image=image,
+            runtime_class_name=runtime_class,
+            vcpus=vcpus,
+            mem_mib=mem_mib,
+            egress=egress,
+            terminal=terminal,
+            volumes=volumes,
+            volume_mounts=volume_mounts,
+            image_pull_secrets=image_pull_secrets,
+            workspace_size=workspace_size,
+            target_node=target_node,
+            operating_mode=operating_mode,
+            manifest=manifest,
+        )
+        response = self._http.post(
+            self._collection_path(),
+            json=request.model_dump(by_alias=True, exclude_none=True),
+        )
+        info = self._parse_info(response)
+        # Backend may briefly report Unknown/empty phase right after create;
+        # default to Pending so callers can wait on it.
+        if info.status == SandboxV2Status.UNKNOWN:
+            info.status = SandboxV2Status.PENDING
+        return info
+
+    def get(self, name: str) -> SandboxV2Info:
+        """Get information about a sandbox."""
+        response = self._http.get(self._sandbox_path(name))
+        return self._parse_info(response)
+
+    def list(self) -> list[SandboxV2Info]:
+        """List all Firecracker sandboxes in the configured namespace."""
+        response = self._http.get(self._collection_path())
+        sandboxes = response.get("sandboxes", [])
+        return [self._parse_info(s) for s in sandboxes]
+
+    def pause(self, name: str) -> SandboxV2Info:
+        """Pause a running sandbox (native VM snapshot -> Hibernated)."""
+        try:
+            response = self._http.post(self._sandbox_sub_path(name, "pause"))
+        except ProKubeError as e:
+            if e.status_code == 409:
+                raise SandboxError(str(e), status_code=409) from e
+            raise
+        return self._parse_info(response)
+
+    def resume(self, name: str) -> SandboxV2Info:
+        """Resume a paused sandbox (native VM restore -> Running)."""
+        try:
+            response = self._http.post(self._sandbox_sub_path(name, "resume"))
+        except ProKubeError as e:
+            if e.status_code == 409:
+                raise SandboxError(str(e), status_code=409) from e
+            raise
+        return self._parse_info(response)
+
+    def delete(self, name: str) -> None:
+        """Delete a sandbox (deletes the CR; ephemeral PVC cleaned up)."""
+        self._http.delete(self._sandbox_path(name))
+
+    # -- exec -----------------------------------------------------------------
+
+    def exec_code(
+        self,
+        name: str,
+        code: str,
+        language: str = "python",
+        timeout: int = 300,
+        session_id: str | None = None,
+        reset_session: bool = False,
+    ) -> CodeResult:
+        """Execute code in the guest Jupyter kernel (stateful)."""
+        request = ExecV2Request(
+            code=code,
+            language=language,
+            timeout=min(timeout, 300),
+            use_jupyter=True,
+            session_id=session_id,
+            reset_session=reset_session,
+        )
+        response = self._http.post(
+            self._sandbox_sub_path(name, "exec"),
+            json=request.model_dump(exclude_none=True),
+        )
+        exit_code = response.get("exitCode", 0)
+        success = response.get("success")
+        if success is None:
+            success = exit_code == 0
+        return CodeResult(
+            stdout=response.get("stdout", ""),
+            stderr=response.get("stderr", ""),
+            success=bool(success),
+            execution_time_ms=response.get("durationMs", 0),
+            session_id=response.get("session_id"),
+        )
+
+    def exec_command(
+        self,
+        name: str,
+        command: str,
+        timeout: int = 300,
+    ) -> CommandResult:
+        """Execute a shell command in the guest.
+
+        v2's ``/exec`` endpoint runs a raw shell command when ``use_jupyter`` is
+        False and ``language`` is ``bash`` — no separate command endpoint
+        exists, so shell commands ride the same endpoint as code with those
+        settings.
+        """
+        request = ExecV2Request(
+            code=command,
+            language="bash",
+            timeout=min(timeout, 300),
+            use_jupyter=False,
+        )
+        response = self._http.post(
+            self._sandbox_sub_path(name, "exec"),
+            json=request.model_dump(
+                exclude={"session_id", "reset_session"}
+            ),
+        )
+        return CommandResult(
+            stdout=response.get("stdout", ""),
+            stderr=response.get("stderr", ""),
+            exit_code=response.get("exitCode", -1),
+            duration_ms=response.get("durationMs", 0),
+        )
+
+    # -- files ----------------------------------------------------------------
+
+    def write_file(self, name: str, path: str, content: bytes) -> None:
+        """Write a file to the guest (base64-encoded on the wire)."""
+        request = UploadFileV2Request(
+            path=path,
+            content=base64.b64encode(content).decode("ascii"),
+            encoding="base64",
+        )
+        self._http.post(
+            self._sandbox_sub_path(name, "files"),
+            json=request.model_dump(),
+        )
+
+    def write_files_batch(
+        self, name: str, items: Sequence[tuple[str, bytes]]
+    ) -> BatchFileWriteResponse:
+        """Write multiple files to the guest in one request."""
+        request = BatchFileWriteRequest(
+            items=[
+                FileWriteRequest(
+                    path=path,
+                    content=base64.b64encode(content).decode("ascii"),
+                    encoding="base64",
+                )
+                for path, content in items
+            ]
+        )
+        try:
+            response = self._http.post(
+                self._sandbox_sub_path(name, "files/batch"),
+                json=request.model_dump(),
+            )
+        except NotFoundError as e:
+            try:
+                self.get(name)
+            except NotFoundError:
+                raise
+            raise SandboxError(
+                "Batch file writes require a backend that supports the "
+                "sandboxv2 /files/batch endpoint",
+                status_code=e.status_code,
+            ) from e
+        except ProKubeError as e:
+            if e.status_code == 405:
+                raise SandboxError(
+                    "Batch file writes require a backend that supports the "
+                    "sandboxv2 /files/batch endpoint",
+                    status_code=e.status_code,
+                ) from e
+            raise
+        return _parse_batch_file_write_response(response)
+
+    def read_file(self, name: str, path: str) -> bytes:
+        """Read a file from the guest."""
+        return self._http.get_bytes(
+            self._sandbox_sub_path(name, "files/download"),
+            params={"path": path},
+        )
+
+    def list_files(self, name: str, path: str = "/workspace") -> list[FileInfo]:
+        """List files in a guest directory."""
+        response = self._http.get(
+            self._sandbox_sub_path(name, "files"),
+            params={"path": path},
+        )
+        files = response.get("files", [])
+        return [
+            FileInfo(
+                name=f["name"],
+                path=f["path"],
+                # v2 backend uses isDirectory/modifiedAt; keep v1 aliases too.
+                is_dir=f.get("isDirectory", f.get("is_dir", f.get("isDir", False))),
+                size=f.get("size", 0),
+                modified=f.get("modifiedAt", f.get("modified")),
+            )
+            for f in files
+        ]

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -36,9 +36,12 @@ from prokube.sandbox.models import (
 from prokube.sandboxv2.models import (
     CodeResult,
     CommandResult,
+    CreateHibernatedPoolRequest,
     CreateSandboxV2Request,
     ExecV2Request,
     FileInfo,
+    HibernatedPoolInfo,
+    HibernatedPoolMember,
     SandboxV2Info,
     SandboxV2Status,
     UploadFileV2Request,
@@ -109,6 +112,16 @@ class SandboxV2Client:
 
     def _sandbox_sub_path(self, name: str, sub: str) -> str:
         return f"{self._sandbox_path(name)}/{sub}"
+
+    def _pools_path(self) -> str:
+        # Sibling collection of ``sandboxv2`` (``sandboxv2-pools``), NOT a
+        # sub-path of it — mirrors the pkui backend route registration.
+        return (
+            f"{self._prefix()}/api/namespaces/{self._namespace()}/sandboxv2-pools"
+        )
+
+    def _pool_path(self, name: str) -> str:
+        return f"{self._pools_path()}/{name}"
 
     # -- parsing --------------------------------------------------------------
 
@@ -217,6 +230,82 @@ class SandboxV2Client:
     def delete(self, name: str) -> None:
         """Delete a sandbox (deletes the CR; ephemeral PVC cleaned up)."""
         self._http.delete(self._sandbox_path(name))
+
+    # -- pools (FirecrackerHibernatedPool) ------------------------------------
+
+    def _parse_pool(self, response: dict[str, object]) -> HibernatedPoolInfo:
+        members = [
+            HibernatedPoolMember(name=m.get("name", ""), phase=m.get("phase"))
+            for m in (response.get("members") or [])
+            if m.get("name")
+        ]
+        return HibernatedPoolInfo(
+            name=response.get("name", ""),
+            namespace=response.get("namespace", self._namespace()),
+            size=response.get("size", 0) or 0,
+            ready_members=response.get("readyMembers", 0) or 0,
+            members=members,
+            image=response.get("image") or None,
+            runtime_class_name=response.get("runtimeClassName"),
+            message=response.get("message"),
+            created_at=response.get("createdAt"),
+        )
+
+    def create_pool(
+        self,
+        name: str,
+        size: int,
+        template: CreateSandboxV2Request,
+    ) -> HibernatedPoolInfo:
+        """Create a warm pool of pre-hibernated Firecracker sandboxes.
+
+        Args:
+            name: Pool name.
+            size: Desired number of warm (pre-hibernated) members.
+            template: The v2 sandbox create spec used as the member template
+                (same knobs as :meth:`create`). The backend forces the template
+                to ``runtimeClassName: fc-host`` and owns ``operatingMode``.
+        """
+        request = CreateHibernatedPoolRequest(
+            name=name, size=size, template=template
+        )
+        response = self._http.post(
+            self._pools_path(),
+            json=request.model_dump(by_alias=True, exclude_none=True),
+        )
+        return self._parse_pool(response)
+
+    def list_pools(self) -> list[HibernatedPoolInfo]:
+        """List all warm pools in the configured namespace."""
+        response = self._http.get(self._pools_path())
+        pools = response.get("pools", [])
+        return [self._parse_pool(p) for p in pools]
+
+    def get_pool(self, name: str) -> HibernatedPoolInfo:
+        """Get information about a warm pool."""
+        response = self._http.get(self._pool_path(name))
+        return self._parse_pool(response)
+
+    def delete_pool(self, name: str) -> None:
+        """Delete a warm pool (the controller garbage-collects its members)."""
+        self._http.delete(self._pool_path(name))
+
+    def claim(self, name: str) -> SandboxV2Info:
+        """Claim a ready member from a warm pool (fast resume, not cold boot).
+
+        Returns the now-resuming sandbox, detached from the pool. The pool
+        controller refills to keep ``spec.size`` warm.
+
+        Raises:
+            SandboxError: If no warm member is ready to claim (HTTP 409).
+        """
+        try:
+            response = self._http.post(f"{self._pool_path(name)}/claim")
+        except ProKubeError as e:
+            if e.status_code == 409:
+                raise SandboxError(str(e), status_code=409) from e
+            raise
+        return self._parse_info(response)
 
     # -- exec -----------------------------------------------------------------
 

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -45,6 +45,7 @@ from prokube.sandboxv2.models import (
     CommandResult,
     CreateHibernatedPoolRequest,
     CreateSandboxV2Request,
+    DNSConfig,
     ExecV2Request,
     FileInfo,
     HibernatedPoolInfo,
@@ -184,6 +185,8 @@ class SandboxV2Client:
         operating_mode: str | None = None,
         startup_probe: Probe | dict[str, object] | None = None,
         lifecycle: Lifecycle | dict[str, object] | None = None,
+        dns_policy: str | None = None,
+        dns_config: DNSConfig | dict[str, object] | None = None,
         manifest: dict[str, object] | None = None,
     ) -> SandboxV2Info:
         """Create a new Firecracker sandbox.
@@ -201,6 +204,12 @@ class SandboxV2Client:
         readiness/warm-up knobs. Each accepts a model instance or a CR-shaped
         dict. Omitted -> the backend fills the pk-sandbox-base execd defaults, so
         existing callers are unaffected.
+
+        ``dns_policy`` (spec.dnsPolicy: ClusterFirst | None | Default) and
+        ``dns_config`` (spec.dnsConfig, Pod-mirrored nameservers/searches/options)
+        control the guest ``/etc/resolv.conf`` written host-side at cold boot.
+        ``dns_config`` accepts a model instance or a CR-shaped dict. Omitted ->
+        the executor ClusterFirst default, so existing callers are unaffected.
         """
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
@@ -223,6 +232,8 @@ class SandboxV2Client:
             operating_mode=operating_mode,
             startup_probe=startup_probe,
             lifecycle=lifecycle,
+            dns_policy=dns_policy,
+            dns_config=dns_config,
             manifest=manifest,
         )
         response = self._http.post(

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -49,6 +49,8 @@ from prokube.sandboxv2.models import (
     FileInfo,
     HibernatedPoolInfo,
     HibernatedPoolMember,
+    Lifecycle,
+    Probe,
     SandboxV2Info,
     SandboxV2Status,
     UpdatePoolRequest,
@@ -180,6 +182,8 @@ class SandboxV2Client:
         workspace_size: str | None = None,
         target_node: str | None = None,
         operating_mode: str | None = None,
+        startup_probe: Probe | dict[str, object] | None = None,
+        lifecycle: Lifecycle | dict[str, object] | None = None,
         manifest: dict[str, object] | None = None,
     ) -> SandboxV2Info:
         """Create a new Firecracker sandbox.
@@ -191,6 +195,12 @@ class SandboxV2Client:
         dicts and serializes to CRD ``spec.env``; ``secret_refs`` accepts a list
         of Secret names and serializes to CRD ``spec.envFrom``. Env is baked into
         the guest at boot/snapshot and is not refreshed on pause/resume.
+
+        ``startup_probe`` (spec.startupProbe, core/v1 Probe) and ``lifecycle``
+        (spec.lifecycle with ``postStart``, core/v1 Lifecycle) are Pod-mirrored
+        readiness/warm-up knobs. Each accepts a model instance or a CR-shaped
+        dict. Omitted -> the backend fills the pk-sandbox-base execd defaults, so
+        existing callers are unaffected.
         """
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
@@ -211,6 +221,8 @@ class SandboxV2Client:
             workspace_size=workspace_size,
             target_node=target_node,
             operating_mode=operating_mode,
+            startup_probe=startup_probe,
+            lifecycle=lifecycle,
             manifest=manifest,
         )
         response = self._http.post(

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -448,12 +448,12 @@ class SandboxV2Client:
         session_id: str | None = None,
         reset_session: bool = False,
     ) -> CodeResult:
-        """Execute code in the guest Jupyter kernel (stateful)."""
+        """Execute code in the persistent per-language session (stateful)."""
         request = ExecV2Request(
             code=code,
             language=language,
             timeout=min(timeout, 300),
-            use_jupyter=True,
+            stateful=True,
             session_id=session_id,
             reset_session=reset_session,
         )
@@ -479,18 +479,19 @@ class SandboxV2Client:
         command: str,
         timeout: int = 300,
     ) -> CommandResult:
-        """Execute a shell command in the guest.
+        """Execute a shell command in the guest (one-shot, stateless).
 
-        v2's ``/exec`` endpoint runs a raw shell command when ``use_jupyter`` is
+        v2's ``/exec`` endpoint runs a raw shell command when ``stateful`` is
         False and ``language`` is ``bash`` — no separate command endpoint
         exists, so shell commands ride the same endpoint as code with those
-        settings.
+        settings (backend routes ``stateful=false`` to the stateless
+        ``/command`` path).
         """
         request = ExecV2Request(
             code=command,
             language="bash",
             timeout=min(timeout, 300),
-            use_jupyter=False,
+            stateful=False,
         )
         response = self._http.post(
             self._sandbox_sub_path(name, "exec"),

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -153,6 +153,8 @@ class SandboxV2Client:
         mem_mib: int | None = None,
         egress: bool = False,
         terminal: bool = True,
+        env_vars: dict[str, str] | list[dict[str, str]] | None = None,
+        secret_refs: list[str] | None = None,
         volumes: list[dict[str, object]] | None = None,
         volume_mounts: list[dict[str, object]] | None = None,
         image_pull_secrets: list[str] | None = None,
@@ -165,6 +167,11 @@ class SandboxV2Client:
 
         Returns as soon as the CR is created; the controller drives
         Pending -> Running asynchronously (poll via :meth:`get`).
+
+        ``env_vars`` accepts a ``dict[str,str]`` or a list of ``{name,value}``
+        dicts and serializes to CRD ``spec.env``; ``secret_refs`` accepts a list
+        of Secret names and serializes to CRD ``spec.envFrom``. Env is baked into
+        the guest at boot/snapshot and is not refreshed on pause/resume.
         """
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
@@ -177,6 +184,8 @@ class SandboxV2Client:
             mem_mib=mem_mib,
             egress=egress,
             terminal=terminal,
+            env=env_vars,
+            env_from=secret_refs,
             volumes=volumes,
             volume_mounts=volume_mounts,
             image_pull_secrets=image_pull_secrets,

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -187,6 +187,7 @@ class SandboxV2Client:
         lifecycle: Lifecycle | dict[str, object] | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict[str, object] | None = None,
+        snapshot_resume_policy: str | None = None,
         manifest: dict[str, object] | None = None,
     ) -> SandboxV2Info:
         """Create a new Firecracker sandbox.
@@ -210,6 +211,11 @@ class SandboxV2Client:
         control the guest ``/etc/resolv.conf`` written host-side at cold boot.
         ``dns_config`` accepts a model instance or a CR-shaped dict. Omitted ->
         the executor ClusterFirst default, so existing callers are unaffected.
+
+        ``snapshot_resume_policy`` (spec.snapshotResumePolicy: Strict |
+        AllowStale) controls whether resuming from a pool member's snapshot
+        requires an exact recipe/base match. Omitted -> the executor Strict
+        default, so existing callers are unaffected.
         """
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
@@ -234,6 +240,7 @@ class SandboxV2Client:
             lifecycle=lifecycle,
             dns_policy=dns_policy,
             dns_config=dns_config,
+            snapshot_resume_policy=snapshot_resume_policy,
             manifest=manifest,
         )
         response = self._http.post(

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -187,6 +187,7 @@ class SandboxV2Client:
         lifecycle: Lifecycle | dict[str, object] | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict[str, object] | None = None,
+        mesh: bool | None = None,
         manifest: dict[str, object] | None = None,
     ) -> SandboxV2Info:
         """Create a new Firecracker sandbox.
@@ -210,6 +211,9 @@ class SandboxV2Client:
         control the guest ``/etc/resolv.conf`` written host-side at cold boot.
         ``dns_config`` accepts a model instance or a CR-shaped dict. Omitted ->
         the executor ClusterFirst default, so existing callers are unaffected.
+
+        ``mesh`` is Optional: opt this sandbox into the Istio service mesh
+        (spec.mesh).
         """
         if name is None:
             name = f"sandbox-{uuid.uuid4().hex[:8]}"
@@ -234,6 +238,7 @@ class SandboxV2Client:
             lifecycle=lifecycle,
             dns_policy=dns_policy,
             dns_config=dns_config,
+            mesh=mesh,
             manifest=manifest,
         )
         response = self._http.post(

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -4,11 +4,18 @@ Reuses ``prokube.common`` verbatim (same ``x-api-key`` auth, http client,
 config, exceptions) and the v1 execd result models. Only the path space and the
 create/get/pause/resume lifecycle differ from v1:
 
-* v1 paths:  ``/sandbox/{ws}/sandboxes/...`` (external) or
+* v1 paths:  ``/sandbox/{ws}/sandboxes/...`` (external / api-key) or
   ``/_platform/sandbox/{ws}/sandboxes/...`` (in-cluster).
-* v2 paths:  ``/api/namespaces/{ns}/sandboxv2/...`` — the FastAPI router is
-  mounted at ``/api`` and is namespaced. v1's ``workspace`` concept maps 1:1 to
-  the v2 ``namespace``.
+* v2 paths mirror the same api-key vs in-cluster branch:
+  - api-key (external ORIGIN route): ``/sandboxv2/{ws}/sandboxes/...`` —
+    top-level on the ingress gateway (no ``/pkui`` prefix, no ``/api``), because
+    the shared :class:`HttpClient` strips ``api_url`` to its origin under an
+    api key. This exactly mirrors v1's external ``/sandbox/{ws}/...`` routes.
+  - in-cluster: ``/api/namespaces/{ws}/sandboxv2/...`` — the FastAPI router is
+    mounted at ``/api`` and is namespaced.
+
+``workspace`` is the v1 name for the Kubernetes namespace; the two are the same
+thing and it is used verbatim in every v2 path.
 
 The exposed method surface (``exec_code`` / ``exec_command`` / ``write_file`` /
 ``read_file`` / ``list_files`` / ``write_files_batch``) matches v1's
@@ -22,7 +29,6 @@ import base64
 import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
@@ -31,6 +37,7 @@ from prokube.sandbox.client import _parse_batch_file_write_response
 from prokube.sandbox.models import (
     BatchFileWriteRequest,
     BatchFileWriteResponse,
+    ClaimRequest,
     FileWriteRequest,
 )
 from prokube.sandboxv2.models import (
@@ -70,8 +77,8 @@ class SandboxV2Client:
         """Initialize the v2 sandbox client.
 
         Args:
-            config: SDK configuration. ``config.workspace`` is used as the v2
-                namespace.
+            config: SDK configuration. ``config.workspace`` is the workspace
+                (Kubernetes namespace) used in every v2 path.
             check_version: Whether to check backend version compatibility.
         """
         self.config = config
@@ -85,27 +92,23 @@ class SandboxV2Client:
         self._http.close()
 
     # -- path helpers ---------------------------------------------------------
+    #
+    # Every path method branches on ``use_api_key`` exactly like v1's
+    # ``SandboxClient._sandboxes_path`` / ``PoolClient._pools_path``:
+    #
+    # * api-key -> top-level ORIGIN routes (``/sandboxv2/{ws}/...``). The shared
+    #   ``HttpClient`` uses only the ``api_url`` origin under an api key, so NO
+    #   ``/pkui`` prefix and NO ``/api`` segment may be attached here.
+    # * in-cluster -> namespaced FastAPI routes (``/api/namespaces/{ws}/...``).
 
-    def _namespace(self) -> str:
+    def _workspace(self) -> str:
         return self.config.workspace
 
-    def _prefix(self) -> str:
-        """Path prefix to prepend under API-key (external) access.
-
-        The shared ``HttpClient`` strips ``api_url`` down to its origin for
-        API-key access (v1's external ``/sandbox/*`` routes are top-level). The
-        v2 routes, by contrast, live under the app's own path prefix
-        (e.g. ``/pkui/api/namespaces/...``), so when using an API key we must
-        re-attach the configured path prefix. For in-cluster access the full
-        ``api_url`` (prefix included) is preserved by ``HttpClient`` already, so
-        no prefix is added here.
-        """
-        if self.config.use_api_key:
-            return urlparse(self.config.api_url).path.rstrip("/")
-        return ""
-
     def _collection_path(self) -> str:
-        return f"{self._prefix()}/api/namespaces/{self._namespace()}/sandboxv2"
+        ws = self._workspace()
+        if self.config.use_api_key:
+            return f"/sandboxv2/{ws}/sandboxes"
+        return f"/api/namespaces/{ws}/sandboxv2"
 
     def _sandbox_path(self, name: str) -> str:
         return f"{self._collection_path()}/{name}"
@@ -113,12 +116,27 @@ class SandboxV2Client:
     def _sandbox_sub_path(self, name: str, sub: str) -> str:
         return f"{self._sandbox_path(name)}/{sub}"
 
+    def _claim_path(self) -> str:
+        """POST target for claiming a warm-pool member.
+
+        Under api-key this is the ORIGIN route ``/sandboxv2/{ws}/sandboxes/claim``
+        (pool name travels in the JSON body, exactly as v1's
+        ``claim_from_pool``). In-cluster claims instead POST to
+        ``.../sandboxv2-pools/{pool}/claim`` (pool name in the URL); see
+        :meth:`claim`.
+        """
+        return f"{self._collection_path()}/claim"
+
     def _pools_path(self) -> str:
-        # Sibling collection of ``sandboxv2`` (``sandboxv2-pools``), NOT a
-        # sub-path of it — mirrors the pkui backend route registration.
-        return (
-            f"{self._prefix()}/api/namespaces/{self._namespace()}/sandboxv2-pools"
-        )
+        ws = self._workspace()
+        if self.config.use_api_key:
+            # Pool CRUD is not part of the deployed api-key ORIGIN contract
+            # (only pool *claim* is exposed, via the sandboxes/claim route
+            # above). Provide a consistent top-level path for completeness.
+            return f"/sandboxv2/{ws}/pools"
+        # In-cluster: sibling collection of ``sandboxv2`` (``sandboxv2-pools``),
+        # NOT a sub-path of it — mirrors the pkui backend route registration.
+        return f"/api/namespaces/{ws}/sandboxv2-pools"
 
     def _pool_path(self, name: str) -> str:
         return f"{self._pools_path()}/{name}"
@@ -128,7 +146,7 @@ class SandboxV2Client:
     def _parse_info(self, response: dict[str, object]) -> SandboxV2Info:
         return SandboxV2Info(
             name=response.get("name", ""),
-            namespace=response.get("namespace", self._namespace()),
+            workspace=response.get("namespace", self._workspace()),
             status=_parse_status(
                 response.get("phase"), SandboxV2Status.UNKNOWN
             ),
@@ -211,7 +229,7 @@ class SandboxV2Client:
         return self._parse_info(response)
 
     def list(self) -> list[SandboxV2Info]:
-        """List all Firecracker sandboxes in the configured namespace."""
+        """List all Firecracker sandboxes in the configured workspace."""
         response = self._http.get(self._collection_path())
         sandboxes = response.get("sandboxes", [])
         return [self._parse_info(s) for s in sandboxes]
@@ -250,7 +268,7 @@ class SandboxV2Client:
         ]
         return HibernatedPoolInfo(
             name=response.get("name", ""),
-            namespace=response.get("namespace", self._namespace()),
+            workspace=response.get("namespace", self._workspace()),
             size=response.get("size", 0) or 0,
             ready_members=response.get("readyMembers", 0) or 0,
             members=members,
@@ -285,7 +303,7 @@ class SandboxV2Client:
         return self._parse_pool(response)
 
     def list_pools(self) -> list[HibernatedPoolInfo]:
-        """List all warm pools in the configured namespace."""
+        """List all warm pools in the configured workspace."""
         response = self._http.get(self._pools_path())
         pools = response.get("pools", [])
         return [self._parse_pool(p) for p in pools]
@@ -299,17 +317,42 @@ class SandboxV2Client:
         """Delete a warm pool (the controller garbage-collects its members)."""
         self._http.delete(self._pool_path(name))
 
-    def claim(self, name: str) -> SandboxV2Info:
+    def claim(
+        self, name: str, auto_idle_timeout_seconds: int | None = None
+    ) -> SandboxV2Info:
         """Claim a ready member from a warm pool (fast resume, not cold boot).
 
         Returns the now-resuming sandbox, detached from the pool. The pool
         controller refills to keep ``spec.size`` warm.
 
+        Path/body mirror v1's ``claim_from_pool`` under api-key:
+
+        * api-key -> ``POST /sandboxv2/{ws}/sandboxes/claim`` with the pool name
+          in the JSON body (v1's :class:`ClaimRequest` shape: ``poolName`` +
+          optional ``autoIdleTimeoutSeconds``).
+        * in-cluster -> ``POST .../sandboxv2-pools/{pool}/claim`` (pool name in
+          the URL, no body — the existing warm-pool controller contract).
+
+        Args:
+            name: Name of the warm pool to claim from.
+            auto_idle_timeout_seconds: Per-claim auto-idle override in seconds
+                (only forwarded on the api-key origin route).
+
         Raises:
             SandboxError: If no warm member is ready to claim (HTTP 409).
         """
         try:
-            response = self._http.post(f"{self._pool_path(name)}/claim")
+            if self.config.use_api_key:
+                request = ClaimRequest(
+                    pool_name=name,
+                    auto_idle_timeout_seconds=auto_idle_timeout_seconds,
+                )
+                response = self._http.post(
+                    self._claim_path(),
+                    json=request.model_dump(by_alias=True, exclude_none=True),
+                )
+            else:
+                response = self._http.post(f"{self._pool_path(name)}/claim")
         except ProKubeError as e:
             if e.status_code == 409:
                 raise SandboxError(str(e), status_code=409) from e

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -51,6 +51,7 @@ from prokube.sandboxv2.models import (
     HibernatedPoolMember,
     SandboxV2Info,
     SandboxV2Status,
+    UpdatePoolRequest,
     UploadFileV2Request,
 )
 
@@ -270,6 +271,7 @@ class SandboxV2Client:
             name=response.get("name", ""),
             workspace=response.get("namespace", self._workspace()),
             size=response.get("size", 0) or 0,
+            warm_state=response.get("warmState") or "Hibernated",
             ready_members=response.get("readyMembers", 0) or 0,
             members=members,
             image=response.get("image") or None,
@@ -283,21 +285,43 @@ class SandboxV2Client:
         name: str,
         size: int,
         template: CreateSandboxV2Request,
+        warm_state: str = "Hibernated",
     ) -> HibernatedPoolInfo:
-        """Create a warm pool of pre-hibernated Firecracker sandboxes.
+        """Create a warm pool of Firecracker sandboxes.
 
         Args:
             name: Pool name.
-            size: Desired number of warm (pre-hibernated) members.
+            size: Desired number of warm members.
             template: The v2 sandbox create spec used as the member template
                 (same knobs as :meth:`create`). The backend forces the template
                 to ``runtimeClassName: fc-host`` and owns ``operatingMode``.
+            warm_state: How warm members are kept — ``"Hibernated"`` (default,
+                pre-snapshotted; a claim is a fast resume) or ``"Running"``
+                (members kept hot). Editable later via :meth:`set_pool_warm_state`.
         """
         request = CreateHibernatedPoolRequest(
-            name=name, size=size, template=template
+            name=name, size=size, warm_state=warm_state, template=template
         )
         response = self._http.post(
             self._pools_path(),
+            json=request.model_dump(by_alias=True, exclude_none=True),
+        )
+        return self._parse_pool(response)
+
+    def set_pool_warm_state(
+        self, name: str, warm_state: str
+    ) -> HibernatedPoolInfo:
+        """Change a pool's ``warmState`` post-create (Hibernated <-> Running).
+
+        The fc controller reconciles every member to the new state.
+
+        Args:
+            name: Pool name.
+            warm_state: ``"Hibernated"`` or ``"Running"``.
+        """
+        request = UpdatePoolRequest(warm_state=warm_state)
+        response = self._http.patch(
+            self._pool_path(name),
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
         return self._parse_pool(response)

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -228,6 +228,25 @@ class SandboxV2Client:
         response = self._http.get(self._sandbox_path(name))
         return self._parse_info(response)
 
+    def wait_ready(self, name: str, timeout: int = 30) -> SandboxV2Info:
+        """Server-side long-poll for readiness (single request).
+
+        The backend tight-polls committed CR state in-cluster and returns the
+        moment ``status.phase`` reaches Running (or Failed), or the latest phase
+        when its ``timeout`` elapses. This collapses the old flat client poll
+        (and its per-poll internet round-trip) into one request resolved near the
+        control-plane. Raises :class:`~prokube.common.exceptions.NotFoundError`
+        when the endpoint is absent (older backend) or the sandbox is missing —
+        the caller then falls back to a local ``get`` poll.
+        """
+        response = self._http.get(
+            self._sandbox_sub_path(name, "wait_ready"),
+            params={"timeout": timeout},
+            # Give httpx headroom over the server-side long-poll window.
+            timeout=timeout + 10,
+        )
+        return self._parse_info(response)
+
     def list(self) -> list[SandboxV2Info]:
         """List all Firecracker sandboxes in the configured workspace."""
         response = self._http.get(self._collection_path())

--- a/src/prokube/sandboxv2/client.py
+++ b/src/prokube/sandboxv2/client.py
@@ -62,9 +62,7 @@ if TYPE_CHECKING:
     from prokube.common.config import Config
 
 
-def _parse_status(
-    status_str: str | None, default: SandboxV2Status
-) -> SandboxV2Status:
+def _parse_status(status_str: str | None, default: SandboxV2Status) -> SandboxV2Status:
     """Parse a phase string to SandboxV2Status, tolerating unknown values."""
     if not status_str:
         return default
@@ -151,9 +149,7 @@ class SandboxV2Client:
         return SandboxV2Info(
             name=response.get("name", ""),
             workspace=response.get("namespace", self._workspace()),
-            status=_parse_status(
-                response.get("phase"), SandboxV2Status.UNKNOWN
-            ),
+            status=_parse_status(response.get("phase"), SandboxV2Status.UNKNOWN),
             image=response.get("image") or None,
             runtime_class=response.get("runtimeClassName"),
             operating_mode=response.get("operatingMode") or None,
@@ -259,12 +255,15 @@ class SandboxV2Client:
             info.status = SandboxV2Status.PENDING
         return info
 
-    def get(self, name: str) -> SandboxV2Info:
+    def get(self, name: str, request_timeout: float | None = None) -> SandboxV2Info:
         """Get information about a sandbox."""
-        response = self._http.get(self._sandbox_path(name))
+        kwargs = {"timeout": request_timeout} if request_timeout is not None else {}
+        response = self._http.get(self._sandbox_path(name), **kwargs)
         return self._parse_info(response)
 
-    def wait_ready(self, name: str, timeout: int = 30) -> SandboxV2Info:
+    def wait_ready(
+        self, name: str, timeout: int = 30, request_timeout: float | None = None
+    ) -> SandboxV2Info:
         """Server-side long-poll for readiness (single request).
 
         The backend tight-polls committed CR state in-cluster and returns the
@@ -278,8 +277,10 @@ class SandboxV2Client:
         response = self._http.get(
             self._sandbox_sub_path(name, "wait_ready"),
             params={"timeout": timeout},
-            # Give httpx headroom over the server-side long-poll window.
-            timeout=timeout + 10,
+            # Normal direct calls get headroom over the server-side long-poll
+            # window. Callers with an overall deadline can pass request_timeout
+            # to keep this single HTTP request within their remaining budget.
+            timeout=request_timeout if request_timeout is not None else timeout + 10,
         )
         return self._parse_info(response)
 
@@ -362,9 +363,7 @@ class SandboxV2Client:
         )
         return self._parse_pool(response)
 
-    def set_pool_warm_state(
-        self, name: str, warm_state: str
-    ) -> HibernatedPoolInfo:
+    def set_pool_warm_state(self, name: str, warm_state: str) -> HibernatedPoolInfo:
         """Change a pool's ``warmState`` post-create (Hibernated <-> Running).
 
         The fc controller reconciles every member to the new state.
@@ -495,9 +494,7 @@ class SandboxV2Client:
         )
         response = self._http.post(
             self._sandbox_sub_path(name, "exec"),
-            json=request.model_dump(
-                exclude={"session_id", "reset_session"}
-            ),
+            json=request.model_dump(exclude={"session_id", "reset_session"}),
         )
         return CommandResult(
             stdout=response.get("stdout", ""),

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Result/file models are reused verbatim from v1 so the public result surface
 # (``.success`` / ``.stdout`` / ``.stderr`` / ``FileInfo``) is identical.
@@ -106,6 +106,149 @@ class EnvFromSource(BaseModel):
     )
 
 
+# =============================================================================
+# Health & warm-up — Pod-mirrored spec.startupProbe (core/v1 Probe) and
+# spec.lifecycle.postStart (core/v1 LifecycleHandler). See
+# docs/rfc-declarative-probes-lifecycle.md §3. Every field is optional; when a
+# create request omits ``startupProbe`` / ``lifecycle`` the backend CR builder
+# fills the pk-sandbox-base execd defaults (§6), so existing callers are
+# unaffected (``exclude_none=True`` drops the omitted fields entirely).
+#
+# The one documented deviation from stock Pod ``HTTPGetAction`` is the
+# ``method`` + ``body`` superset on ``httpGet`` (default method GET) so a warm-up
+# can POST execd's ``/code``. Field names mirror the pkui backend models
+# (``modules/sandboxv2/models.py``) one-for-one so the serialized JSON is the
+# exact shape the backend accepts.
+# =============================================================================
+
+
+class HTTPHeader(BaseModel):
+    """One ``httpGet.httpHeaders`` entry (core/v1 HTTPHeader)."""
+
+    name: str = Field(..., min_length=1, description="Header name.")
+    value: str = Field(default="", description="Header value.")
+
+
+class HTTPGetAction(BaseModel):
+    """core/v1 HTTPGetAction + the ``method``/``body`` superset (RFC §3)."""
+
+    # Accept both snake_case (Python) and camelCase (CR-shaped dict) input, and
+    # serialize to the CRD camelCase keys via ``model_dump(by_alias=True)``.
+    model_config = ConfigDict(populate_by_name=True)
+
+    port: int = Field(..., description="Guest port to probe/hit.")
+    path: str | None = Field(default=None, description="Request path.")
+    host: str | None = Field(default=None, description="Host header override.")
+    scheme: str | None = Field(default=None, description="HTTP | HTTPS.")
+    http_headers: list[HTTPHeader] | None = Field(
+        default=None,
+        alias="httpHeaders",
+        description="Custom request headers.",
+    )
+    # Superset over stock Pod HTTPGetAction (documented deviation): lets a warm-up
+    # POST a body (e.g. execd /code). Default method is GET when omitted.
+    method: str | None = Field(
+        default=None, description="HTTP method (superset; default GET)."
+    )
+    body: str | None = Field(
+        default=None, description="Request body (superset; used with method POST)."
+    )
+
+
+class TCPSocketAction(BaseModel):
+    """core/v1 TCPSocketAction — a host-side tcp-connect probe."""
+
+    port: int = Field(..., description="Guest port to connect to.")
+    host: str | None = Field(default=None, description="Host to connect to.")
+
+
+class ExecAction(BaseModel):
+    """core/v1 ExecAction — run a command inside the guest (vsock agent)."""
+
+    command: list[str] = Field(
+        ..., min_length=1, description="argv to run inside the guest."
+    )
+
+
+def _handler_count(
+    http_get: HTTPGetAction | None,
+    tcp_socket: TCPSocketAction | None,
+    exec_action: ExecAction | None,
+) -> int:
+    return sum(1 for h in (http_get, tcp_socket, exec_action) if h is not None)
+
+
+class Probe(BaseModel):
+    """core/v1 Probe — exactly one of ``httpGet`` / ``tcpSocket`` / ``exec``.
+
+    Serializes to the CRD ``spec.startupProbe`` shape (camelCase handler keys and
+    ``failureThreshold`` etc. via ``model_dump(by_alias=True)``). Accepts both
+    snake_case and camelCase (CR-shaped dict) input.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    http_get: HTTPGetAction | None = Field(default=None, alias="httpGet")
+    tcp_socket: TCPSocketAction | None = Field(default=None, alias="tcpSocket")
+    exec: ExecAction | None = Field(default=None)
+    initial_delay_seconds: int | None = Field(
+        default=None, ge=0, alias="initialDelaySeconds"
+    )
+    period_seconds: int | None = Field(
+        default=None, ge=1, alias="periodSeconds"
+    )
+    timeout_seconds: int | None = Field(
+        default=None, ge=1, alias="timeoutSeconds"
+    )
+    failure_threshold: int | None = Field(
+        default=None, ge=1, alias="failureThreshold"
+    )
+    success_threshold: int | None = Field(
+        default=None, ge=1, alias="successThreshold"
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_handler(self) -> Probe:
+        n = _handler_count(self.http_get, self.tcp_socket, self.exec)
+        if n != 1:
+            raise ValueError(
+                "startupProbe must set exactly one handler "
+                f"(httpGet | tcpSocket | exec), got {n}"
+            )
+        return self
+
+
+class LifecycleHandler(BaseModel):
+    """core/v1 LifecycleHandler — exactly one of ``httpGet`` / ``tcpSocket`` /
+    ``exec``. Serializes to the CRD ``lifecycle.postStart`` shape."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    http_get: HTTPGetAction | None = Field(default=None, alias="httpGet")
+    tcp_socket: TCPSocketAction | None = Field(default=None, alias="tcpSocket")
+    exec: ExecAction | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _exactly_one_handler(self) -> LifecycleHandler:
+        n = _handler_count(self.http_get, self.tcp_socket, self.exec)
+        if n != 1:
+            raise ValueError(
+                "lifecycle.postStart must set exactly one handler "
+                f"(httpGet | tcpSocket | exec), got {n}"
+            )
+        return self
+
+
+class Lifecycle(BaseModel):
+    """core/v1 Lifecycle — only ``postStart`` is modelled (RFC §3 subset)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    post_start: LifecycleHandler | None = Field(
+        default=None, alias="postStart"
+    )
+
+
 class CreateSandboxV2Request(BaseModel):
     """Request body for ``POST .../sandboxv2`` (mirrors backend model)."""
 
@@ -165,6 +308,19 @@ class CreateSandboxV2Request(BaseModel):
         default=None,
         serialization_alias="volumeMounts",
         description="spec.volumeMounts pass-through (CR-shaped dicts)",
+    )
+    startup_probe: Probe | None = Field(
+        default=None,
+        serialization_alias="startupProbe",
+        description="spec.startupProbe (core/v1 Probe) gating boot-readiness. "
+        "Omitted -> the backend fills the pk-sandbox-base execd default "
+        "(httpGet /ping). See docs/rfc-declarative-probes-lifecycle.md §3/§6.",
+    )
+    lifecycle: Lifecycle | None = Field(
+        default=None,
+        description="spec.lifecycle (core/v1 Lifecycle; only postStart modelled) "
+        "— a one-shot warm-up run after the probe passes (baked into a pool "
+        "member's snapshot). Omitted -> the execd /code POST default.",
     )
     manifest: dict[str, Any] | None = Field(
         default=None,

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -249,6 +249,54 @@ class Lifecycle(BaseModel):
     )
 
 
+# =============================================================================
+# Guest DNS — Pod-mirrored spec.dnsPolicy + spec.dnsConfig. The executor writes
+# the guest ``/etc/resolv.conf`` host-side at COLD BOOT (the way a container
+# runtime does), mirroring the Pod spec. Every field is optional; when a create
+# request omits ``dnsPolicy`` / ``dnsConfig`` the executor applies its
+# ClusterFirst default (mirror the pod resolver + append 1.1.1.1), so existing
+# callers are unaffected (``exclude_none=True`` drops the omitted fields).
+# Field names mirror the FirecrackerSandbox CRD / Pod spec one-for-one so the
+# serialized JSON is the exact shape the backend accepts. See
+# docs/sandbox-dns-design.md.
+# =============================================================================
+
+
+class DNSConfigOption(BaseModel):
+    """One ``dnsConfig.options`` entry (Pod PodDNSConfigOption).
+
+    Rendered guest-side as ``name`` or ``name:value``. ``value`` is optional.
+    """
+
+    name: str = Field(..., min_length=1, description="Option name, e.g. ndots.")
+    value: str | None = Field(
+        default=None, description='Optional option value, e.g. "5" for ndots.'
+    )
+
+
+class DNSConfig(BaseModel):
+    """core/v1 PodDNSConfig — resolver config merged into the guest resolv.conf.
+
+    With ``dnsPolicy: None`` it is the ENTIRE config; with ``ClusterFirst`` it
+    augments the mirrored base (nameservers appended, searches merged, options
+    set by name — K8s merge semantics). Accepts both snake_case (Python) and
+    camelCase (CR-shaped dict) input; serializes to the CRD shape via
+    ``model_dump(by_alias=True)``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    nameservers: list[str] | None = Field(
+        default=None, description="Resolver IPs appended to the base nameservers."
+    )
+    searches: list[str] | None = Field(
+        default=None, description="DNS search domains merged into the base list."
+    )
+    options: list[DNSConfigOption] | None = Field(
+        default=None, description="Resolver options set by name."
+    )
+
+
 class CreateSandboxV2Request(BaseModel):
     """Request body for ``POST .../sandboxv2`` (mirrors backend model)."""
 
@@ -321,6 +369,19 @@ class CreateSandboxV2Request(BaseModel):
         description="spec.lifecycle (core/v1 Lifecycle; only postStart modelled) "
         "— a one-shot warm-up run after the probe passes (baked into a pool "
         "member's snapshot). Omitted -> the execd /code POST default.",
+    )
+    dns_policy: str | None = Field(
+        default=None,
+        serialization_alias="dnsPolicy",
+        description="spec.dnsPolicy (ClusterFirst | None | Default) — how the "
+        "guest /etc/resolv.conf is written at cold boot. Omitted -> the executor "
+        "ClusterFirst default (mirror the pod resolver + 1.1.1.1 fallback).",
+    )
+    dns_config: DNSConfig | None = Field(
+        default=None,
+        serialization_alias="dnsConfig",
+        description="spec.dnsConfig (Pod PodDNSConfig) — extra resolver config "
+        "merged into the guest resolv.conf (nameservers/searches/options).",
     )
     manifest: dict[str, Any] | None = Field(
         default=None,

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -383,6 +383,11 @@ class CreateSandboxV2Request(BaseModel):
         description="spec.dnsConfig (Pod PodDNSConfig) — extra resolver config "
         "merged into the guest resolv.conf (nameservers/searches/options).",
     )
+    mesh: bool | None = Field(
+        default=None,
+        description="Optional: opt this sandbox into the Istio service mesh "
+        "(spec.mesh).",
+    )
     manifest: dict[str, Any] | None = Field(
         default=None,
         description="Full FirecrackerSandbox object; wins over structured knobs",

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -165,3 +165,62 @@ class UploadFileV2Request(BaseModel):
     encoding: str = Field(
         default="base64", description="Content encoding ('text' or 'base64')"
     )
+
+
+# =============================================================================
+# FirecrackerHibernatedPool — warm pool of pre-hibernated sandboxes
+#
+# Mirrors the pkui backend ``modules/sandboxv2`` pool DTOs
+# (CreateHibernatedPoolRequest / HibernatedPoolInfo / HibernatedPoolMember).
+# The backend routes live at ``/api/namespaces/{ns}/sandboxv2-pools`` (note:
+# ``sandboxv2-pools``, a sibling collection of ``sandboxv2``, NOT a sub-path).
+# =============================================================================
+
+
+class CreateHibernatedPoolRequest(BaseModel):
+    """Request body for ``POST .../sandboxv2-pools`` (mirrors backend model).
+
+    ``template`` is a full v2 sandbox create spec reused verbatim — the same
+    knobs as :class:`CreateSandboxV2Request` (image, resources, egress,
+    volumes/volumeMounts, targetNode). The backend forces the template to
+    ``runtimeClassName: fc-host`` and owns ``operatingMode`` (the pool
+    controller drives each member to Hibernated), and ignores the template's own
+    ``name`` (members are named by the controller).
+    """
+
+    name: str = Field(..., min_length=1, max_length=63, description="Pool name")
+    size: int = Field(..., ge=0, description="Desired number of warm members")
+    template: CreateSandboxV2Request = Field(
+        ..., description="Sandbox spec used as the pool member template"
+    )
+
+
+class HibernatedPoolMember(BaseModel):
+    """One entry of FirecrackerHibernatedPool ``status.members``."""
+
+    name: str = Field(..., description="Member FirecrackerSandbox name")
+    phase: str | None = Field(
+        default=None, description="Member FirecrackerSandbox status.phase"
+    )
+
+
+class HibernatedPoolInfo(BaseModel):
+    """A FirecrackerHibernatedPool projected from the CR (mirrors backend)."""
+
+    name: str = Field(..., description="Pool (CR) name")
+    namespace: str = Field(..., description="Kubernetes namespace")
+    size: int = Field(default=0, description="spec.size — desired warm members")
+    ready_members: int = Field(
+        default=0, description="status.readyMembers — claimable warm members"
+    )
+    members: list[HibernatedPoolMember] = Field(
+        default_factory=list, description="status.members"
+    )
+    image: str | None = Field(default=None, description="Template base OCI image")
+    runtime_class_name: str | None = Field(
+        default=None, description="Template spec.runtimeClassName (fc-host)"
+    )
+    message: str | None = Field(
+        default=None, description="Human-readable status detail"
+    )
+    created_at: str | None = Field(default=None, description="Creation timestamp")

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -1,0 +1,167 @@
+"""Pydantic models for Sandbox v2 (Firecracker) operations.
+
+The v2 backend contract lives in the pkui ``modules/sandboxv2`` module. The
+execute/file request+response shapes are reused verbatim from v1 (imported from
+``prokube.sandbox.models``) because the guest ``execd`` speaks the identical HTTP
+contract; only the sandbox lifecycle models (create request, sandbox info,
+phase) are v2-specific and defined here.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# Result/file models are reused verbatim from v1 so the public result surface
+# (``.success`` / ``.stdout`` / ``.stderr`` / ``FileInfo``) is identical.
+from prokube.sandbox.models import (  # noqa: F401
+    CodeResult,
+    CommandResult,
+    FileInfo,
+)
+
+
+class SandboxV2Status(str, Enum):
+    """User-facing lifecycle phase of a Firecracker sandbox.
+
+    Mirrors the backend ``SandboxV2Phase`` vocabulary, which folds the raw
+    FirecrackerSandbox status phases (WaitingForImage/Restoring/Hibernating/
+    Hibernated/...) onto the same words v1 uses.
+    """
+
+    PENDING = "Pending"
+    RUNNING = "Running"
+    PAUSED = "Paused"
+    FAILED = "Failed"
+    UNKNOWN = "Unknown"
+
+
+class SandboxV2Info(BaseModel):
+    """Information about a Firecracker sandbox (projected from the CR)."""
+
+    name: str = Field(..., description="Sandbox (CR) name")
+    namespace: str = Field(..., description="Kubernetes namespace")
+    status: SandboxV2Status = Field(
+        default=SandboxV2Status.UNKNOWN, description="User-facing phase"
+    )
+    image: str | None = Field(default=None, description="Base OCI image")
+    runtime_class: str | None = Field(
+        default=None, description="spec.runtimeClassName (fc-host | fc-pod)"
+    )
+    operating_mode: str | None = Field(
+        default=None, description="spec.operatingMode (Running | Hibernated)"
+    )
+    node: str | None = Field(default=None, description="Node hosting the microVM")
+    endpoint: str | None = Field(
+        default=None, description="In-cluster execd Service address"
+    )
+    terminal_enabled: bool = Field(
+        default=True, description="Whether a ttyd Terminal was injected"
+    )
+    message: str | None = Field(
+        default=None, description="Human-readable status detail / failure reason"
+    )
+    created_at: str | None = Field(default=None, description="Creation timestamp")
+
+
+class SandboxV2Resources(BaseModel):
+    """Guest compute request for a Firecracker sandbox."""
+
+    vcpus: int | None = Field(default=None, ge=1, description="Guest vCPUs")
+    mem_mib: int | None = Field(
+        default=None, ge=128, description="Guest memory in MiB"
+    )
+
+
+class CreateSandboxV2Request(BaseModel):
+    """Request body for ``POST .../sandboxv2`` (mirrors backend model)."""
+
+    name: str = Field(..., min_length=1, max_length=63, description="Sandbox name")
+    image: str | None = Field(
+        default=None, description="Base OCI image (defaults to pk-sandbox-base)"
+    )
+    vcpus: int | None = Field(default=None, ge=1, description="Guest vCPUs")
+    mem_mib: int | None = Field(
+        default=None, ge=128, serialization_alias="memMiB", description="Guest MiB"
+    )
+    terminal: bool = Field(
+        default=True, description="Inject a ttyd Terminal (:7681) into the guest"
+    )
+    workspace_size: str | None = Field(
+        default=None,
+        serialization_alias="workspaceSize",
+        description="Ephemeral /workspace volume size (e.g. 10Gi)",
+    )
+    target_node: str | None = Field(
+        default=None,
+        serialization_alias="targetNode",
+        description="Pin the microVM to a node (spec.targetNode)",
+    )
+    image_pull_secrets: list[str] | None = Field(
+        default=None,
+        serialization_alias="imagePullSecrets",
+        description="Registry pull secret names",
+    )
+    runtime_class_name: str | None = Field(
+        default=None,
+        serialization_alias="runtimeClassName",
+        description="spec.runtimeClassName (fc-host | fc-pod)",
+    )
+    operating_mode: str | None = Field(
+        default=None,
+        serialization_alias="operatingMode",
+        description="spec.operatingMode (Running | Hibernated)",
+    )
+    egress: bool | None = Field(
+        default=None,
+        description="spec.egress — true lets the microVM reach the cluster/internet",
+    )
+    volumes: list[dict[str, Any]] | None = Field(
+        default=None, description="spec.volumes pass-through (CR-shaped dicts)"
+    )
+    volume_mounts: list[dict[str, Any]] | None = Field(
+        default=None,
+        serialization_alias="volumeMounts",
+        description="spec.volumeMounts pass-through (CR-shaped dicts)",
+    )
+    manifest: dict[str, Any] | None = Field(
+        default=None,
+        description="Full FirecrackerSandbox object; wins over structured knobs",
+    )
+
+
+class ExecV2Request(BaseModel):
+    """Request body for ``POST .../sandboxv2/{name}/exec``.
+
+    Matches the backend ``ExecuteCodeRequest`` field names verbatim (snake_case
+    on the wire — the v2 exec endpoint does not use camelCase aliases).
+    """
+
+    code: str = Field(..., description="Code or command to execute")
+    language: str = Field(
+        default="bash",
+        description="'bash' for raw commands, 'python'/'node' for code",
+    )
+    timeout: int = Field(default=60, ge=1, le=300, description="Timeout in seconds")
+    workdir: str = Field(default="/workspace", description="Working directory")
+    use_jupyter: bool = Field(
+        default=False, description="Use stateful Jupyter kernel execution"
+    )
+    session_id: str | None = Field(
+        default=None, description="Session ID for stateful Jupyter execution"
+    )
+    reset_session: bool = Field(
+        default=False, description="Restart the Jupyter kernel before executing"
+    )
+
+
+class UploadFileV2Request(BaseModel):
+    """Request body for ``POST .../sandboxv2/{name}/files``."""
+
+    path: str = Field(..., description="Destination path in the guest")
+    content: str = Field(..., description="File content encoded per ``encoding``")
+    encoding: str = Field(
+        default="base64", description="Content encoding ('text' or 'base64')"
+    )

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -42,7 +42,7 @@ class SandboxV2Info(BaseModel):
     """Information about a Firecracker sandbox (projected from the CR)."""
 
     name: str = Field(..., description="Sandbox (CR) name")
-    namespace: str = Field(..., description="Kubernetes namespace")
+    workspace: str = Field(..., description="Workspace (Kubernetes namespace)")
     status: SandboxV2Status = Field(
         default=SandboxV2Status.UNKNOWN, description="User-facing phase"
     )
@@ -284,7 +284,7 @@ class HibernatedPoolInfo(BaseModel):
     """A FirecrackerHibernatedPool projected from the CR (mirrors backend)."""
 
     name: str = Field(..., description="Pool (CR) name")
-    namespace: str = Field(..., description="Kubernetes namespace")
+    workspace: str = Field(..., description="Workspace (Kubernetes namespace)")
     size: int = Field(default=0, description="spec.size — desired warm members")
     ready_members: int = Field(
         default=0, description="status.readyMembers — claimable warm members"

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -244,12 +244,14 @@ class UploadFileV2Request(BaseModel):
 
 
 # =============================================================================
-# FirecrackerHibernatedPool — warm pool of pre-hibernated sandboxes
+# FirecrackerPool — warm pool of sandboxes (Hibernated or Running members)
 #
 # Mirrors the pkui backend ``modules/sandboxv2`` pool DTOs
 # (CreateHibernatedPoolRequest / HibernatedPoolInfo / HibernatedPoolMember).
 # The backend routes live at ``/api/namespaces/{ns}/sandboxv2-pools`` (note:
 # ``sandboxv2-pools``, a sibling collection of ``sandboxv2``, NOT a sub-path).
+# (The k8s kind was renamed FirecrackerHibernatedPool -> FirecrackerPool and
+# gained a ``warmState`` knob; the REST paths are unchanged.)
 # =============================================================================
 
 
@@ -260,19 +262,40 @@ class CreateHibernatedPoolRequest(BaseModel):
     knobs as :class:`CreateSandboxV2Request` (image, resources, egress,
     volumes/volumeMounts, targetNode). The backend forces the template to
     ``runtimeClassName: fc-host`` and owns ``operatingMode`` (the pool
-    controller drives each member to Hibernated), and ignores the template's own
-    ``name`` (members are named by the controller).
+    controller drives each member to the pool's ``warmState``), and ignores the
+    template's own ``name`` (members are named by the controller).
+
+    ``warm_state`` (serialised as ``warmState``) is how warm members are kept:
+    ``"Hibernated"`` (default — pre-snapshotted, a claim is a fast resume) or
+    ``"Running"`` (members kept hot). Editable post-create via ``set_warm_state``.
     """
 
     name: str = Field(..., min_length=1, max_length=63, description="Pool name")
     size: int = Field(..., ge=0, description="Desired number of warm members")
+    warm_state: str = Field(
+        default="Hibernated",
+        serialization_alias="warmState",
+        description="spec.warmState — 'Hibernated' (default) or 'Running'",
+    )
     template: CreateSandboxV2Request = Field(
         ..., description="Sandbox spec used as the pool member template"
     )
 
 
+class UpdatePoolRequest(BaseModel):
+    """Request body for ``PATCH .../sandboxv2-pools/{name}`` — mutable fields.
+
+    Currently ``warm_state`` (serialised as ``warmState``) only."""
+
+    warm_state: str = Field(
+        ...,
+        serialization_alias="warmState",
+        description="spec.warmState — 'Hibernated' or 'Running'",
+    )
+
+
 class HibernatedPoolMember(BaseModel):
-    """One entry of FirecrackerHibernatedPool ``status.members``."""
+    """One entry of FirecrackerPool ``status.members``."""
 
     name: str = Field(..., description="Member FirecrackerSandbox name")
     phase: str | None = Field(
@@ -281,11 +304,15 @@ class HibernatedPoolMember(BaseModel):
 
 
 class HibernatedPoolInfo(BaseModel):
-    """A FirecrackerHibernatedPool projected from the CR (mirrors backend)."""
+    """A FirecrackerPool projected from the CR (mirrors backend)."""
 
     name: str = Field(..., description="Pool (CR) name")
     workspace: str = Field(..., description="Workspace (Kubernetes namespace)")
     size: int = Field(default=0, description="spec.size — desired warm members")
+    warm_state: str = Field(
+        default="Hibernated",
+        description="spec.warmState — 'Hibernated' (default) or 'Running'",
+    )
     ready_members: int = Field(
         default=0, description="status.readyMembers — claimable warm members"
     )

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -383,6 +383,13 @@ class CreateSandboxV2Request(BaseModel):
         description="spec.dnsConfig (Pod PodDNSConfig) — extra resolver config "
         "merged into the guest resolv.conf (nameservers/searches/options).",
     )
+    snapshot_resume_policy: str | None = Field(
+        default=None,
+        serialization_alias="snapshotResumePolicy",
+        description="spec.snapshotResumePolicy (Strict | AllowStale) — whether "
+        "resuming from a pool member's snapshot requires an exact recipe/base "
+        "match. Omitted -> the executor Strict default.",
+    )
     manifest: dict[str, Any] | None = Field(
         default=None,
         description="Full FirecrackerSandbox object; wins over structured knobs",

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # Result/file models are reused verbatim from v1 so the public result surface
 # (``.success`` / ``.stdout`` / ``.stderr`` / ``FileInfo``) is identical.
@@ -75,6 +75,37 @@ class SandboxV2Resources(BaseModel):
     )
 
 
+class EnvVar(BaseModel):
+    """A literal environment variable baked into the guest (spec.env entry).
+
+    Mirrors the Kubernetes ``EnvVar`` (name/value) shape one-for-one so the
+    serialized JSON matches the FirecrackerSandbox CRD ``spec.env`` directly.
+    """
+
+    name: str = Field(..., description="Environment variable name")
+    value: str = Field(..., description="Environment variable value")
+
+
+class SecretEnvSource(BaseModel):
+    """Reference to a Secret by name (spec.envFrom[].secretRef)."""
+
+    name: str = Field(..., description="Secret name in the sandbox namespace")
+
+
+class EnvFromSource(BaseModel):
+    """A ``spec.envFrom`` entry — inject all keys from a Secret as env vars.
+
+    Mirrors the Kubernetes ``EnvFromSource`` shape (``{secretRef: {name}}``) so
+    the serialized JSON matches the FirecrackerSandbox CRD ``spec.envFrom``.
+    """
+
+    secret_ref: SecretEnvSource = Field(
+        ...,
+        serialization_alias="secretRef",
+        description="Secret whose keys are injected into the guest environment",
+    )
+
+
 class CreateSandboxV2Request(BaseModel):
     """Request body for ``POST .../sandboxv2`` (mirrors backend model)."""
 
@@ -118,6 +149,15 @@ class CreateSandboxV2Request(BaseModel):
         default=None,
         description="spec.egress — true lets the microVM reach the cluster/internet",
     )
+    env: list[EnvVar] | None = Field(
+        default=None,
+        description="spec.env — literal env vars ({name,value}) baked into the guest",
+    )
+    env_from: list[EnvFromSource] | None = Field(
+        default=None,
+        serialization_alias="envFrom",
+        description="spec.envFrom — inject all keys from the named Secret(s)",
+    )
     volumes: list[dict[str, Any]] | None = Field(
         default=None, description="spec.volumes pass-through (CR-shaped dicts)"
     )
@@ -130,6 +170,42 @@ class CreateSandboxV2Request(BaseModel):
         default=None,
         description="Full FirecrackerSandbox object; wins over structured knobs",
     )
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _coerce_env(cls, v: Any) -> Any:
+        """Accept a ``dict[str,str]`` or ``list[{name,value}]`` for env vars.
+
+        A mapping is expanded to CRD-shaped ``[{name, value}]`` entries (values
+        stringified); a list of dicts / :class:`EnvVar` is passed through.
+        """
+        if isinstance(v, dict):
+            return [{"name": k, "value": str(val)} for k, val in v.items()]
+        return v
+
+    @field_validator("env_from", mode="before")
+    @classmethod
+    def _coerce_env_from(cls, v: Any) -> Any:
+        """Accept a ``list[str]`` of Secret names for ``envFrom``.
+
+        Each bare Secret name is wrapped into a CRD-shaped
+        ``{secretRef: {name}}`` entry. Already-shaped dicts / model instances
+        pass through unchanged.
+        """
+        if v is None or not isinstance(v, list):
+            return v
+        out: list[Any] = []
+        for item in v:
+            if isinstance(item, str):
+                out.append(EnvFromSource(secret_ref=SecretEnvSource(name=item)))
+            elif isinstance(item, dict) and "secretRef" in item:
+                # CR-shaped {"secretRef": {"name": ...}} — normalize the key.
+                out.append(
+                    EnvFromSource(secret_ref=SecretEnvSource(**item["secretRef"]))
+                )
+            else:
+                out.append(item)
+        return out
 
 
 class ExecV2Request(BaseModel):

--- a/src/prokube/sandboxv2/models.py
+++ b/src/prokube/sandboxv2/models.py
@@ -440,8 +440,14 @@ class CreateSandboxV2Request(BaseModel):
 class ExecV2Request(BaseModel):
     """Request body for ``POST .../sandboxv2/{name}/exec``.
 
-    Matches the backend ``ExecuteCodeRequest`` field names verbatim (snake_case
-    on the wire — the v2 exec endpoint does not use camelCase aliases).
+    Matches the backend V2 exec contract field names verbatim (snake_case on the
+    wire — the v2 exec endpoint does not use camelCase aliases).
+
+    ``stateful`` is the V2 contract flag (replaces the Jupyter-era
+    ``use_jupyter``): ``true`` routes to the persistent per-language session
+    (guest agent ``/code`` path — survives hibernate/resume); ``false`` runs
+    one-shot stateless via the guest ``/command`` path. ``reset_session`` and
+    ``session_id`` are only meaningful when ``stateful`` is true.
     """
 
     code: str = Field(..., description="Code or command to execute")
@@ -451,14 +457,17 @@ class ExecV2Request(BaseModel):
     )
     timeout: int = Field(default=60, ge=1, le=300, description="Timeout in seconds")
     workdir: str = Field(default="/workspace", description="Working directory")
-    use_jupyter: bool = Field(
-        default=False, description="Use stateful Jupyter kernel execution"
+    stateful: bool = Field(
+        default=False,
+        description="Route to the persistent per-language session (true) or "
+        "one-shot stateless execution (false)",
     )
     session_id: str | None = Field(
-        default=None, description="Session ID for stateful Jupyter execution"
+        default=None, description="Session ID for the stateful session"
     )
     reset_session: bool = Field(
-        default=False, description="Restart the Jupyter kernel before executing"
+        default=False,
+        description="Restart the language child before executing (stateful only)",
     )
 
 

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -25,6 +25,7 @@ from prokube.common.exceptions import SandboxError
 from prokube.sandboxv2.client import SandboxV2Client
 from prokube.sandboxv2.models import (
     CreateSandboxV2Request,
+    DNSConfig,
     HibernatedPoolMember,
     Lifecycle,
     Probe,
@@ -236,6 +237,8 @@ class SandboxV2Pool:
         target_node: str | None = None,
         startup_probe: Probe | dict | None = None,
         lifecycle: Lifecycle | dict | None = None,
+        dns_policy: str | None = None,
+        dns_config: DNSConfig | dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -275,6 +278,13 @@ class SandboxV2Pool:
                 its effect rides the resumable snapshot. A
                 :class:`~prokube.sandboxv2.models.Lifecycle` or a CR-shaped dict.
                 Omitted -> backend execd default.
+            dns_policy: spec.dnsPolicy (``ClusterFirst`` | ``None`` | ``Default``)
+                baked into every member template — how each member's guest
+                /etc/resolv.conf is written at cold boot. Omitted -> executor
+                ClusterFirst default.
+            dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
+                options) baked into every member template. A
+                :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
             workspace: Workspace / Kubernetes namespace (default:
                 PROKUBE_WORKSPACE env var).
             api_url / user_id / api_key / timeout: Connection overrides.
@@ -312,6 +322,8 @@ class SandboxV2Pool:
             target_node=target_node,
             startup_probe=startup_probe,
             lifecycle=lifecycle,
+            dns_policy=dns_policy,
+            dns_config=dns_config,
         )
         client = SandboxV2Client(config)
         try:

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -65,6 +65,7 @@ class SandboxV2Pool:
         members: list[HibernatedPoolMember] | None = None,
         image: str | None = None,
         runtime_class: str | None = None,
+        warm_state: str = "Hibernated",
     ) -> None:
         """Initialize a SandboxV2Pool instance.
 
@@ -79,6 +80,7 @@ class SandboxV2Pool:
         self._members = members or []
         self._image = image
         self._runtime_class = runtime_class
+        self._warm_state = warm_state
         self._deleted = False
 
     @property
@@ -121,6 +123,27 @@ class SandboxV2Pool:
         """The template runtime class (always ``fc-host`` for pools)."""
         return self._runtime_class
 
+    @property
+    def warm_state(self) -> str:
+        """How warm members are kept (spec.warmState): ``"Hibernated"`` or
+        ``"Running"``."""
+        return self._warm_state
+
+    def set_warm_state(self, warm_state: str) -> None:
+        """Change this pool's ``warmState`` (Hibernated <-> Running).
+
+        The fc controller reconciles every member to the new state.
+
+        Args:
+            warm_state: ``"Hibernated"`` or ``"Running"``.
+        """
+        self._check_not_deleted()
+        info = self._client.set_pool_warm_state(self._name, warm_state)
+        self._warm_state = info.warm_state
+        self._size = info.size
+        self._ready_members = info.ready_members
+        self._members = info.members
+
     def _check_not_deleted(self) -> None:
         if self._deleted:
             raise SandboxError(f"Pool '{self._name}' has been deleted")
@@ -153,6 +176,7 @@ class SandboxV2Pool:
         self._members = info.members
         self._image = info.image
         self._runtime_class = info.runtime_class_name
+        self._warm_state = info.warm_state
 
     def claim(self) -> SandboxV2:
         """Claim a ready member from this pool (fast resume, not cold boot).
@@ -195,6 +219,7 @@ class SandboxV2Pool:
         size: int,
         image: str | None = None,
         *,
+        warm_state: str = "Hibernated",
         resources: dict | None = None,
         vcpus: int | None = None,
         mem_mib: int | None = None,
@@ -217,8 +242,11 @@ class SandboxV2Pool:
 
         Args:
             name: Pool name.
-            size: Desired number of warm (pre-hibernated) members.
+            size: Desired number of warm members.
             image: Base OCI image for members (defaults to pk-sandbox-base).
+            warm_state: How warm members are kept — ``"Hibernated"`` (default,
+                pre-snapshotted; a claim is a fast resume) or ``"Running"``
+                (members kept hot). Editable later via :meth:`set_warm_state`.
             resources: ``{"vcpus": int, "mem_mib": int}`` shorthand.
             vcpus: Guest vCPUs (overrides ``resources['vcpus']``).
             mem_mib: Guest memory in MiB (overrides ``resources['mem_mib']``).
@@ -272,7 +300,9 @@ class SandboxV2Pool:
         )
         client = SandboxV2Client(config)
         try:
-            info = client.create_pool(name=name, size=size, template=template)
+            info = client.create_pool(
+                name=name, size=size, template=template, warm_state=warm_state
+            )
         except Exception:
             client.close()
             raise
@@ -286,6 +316,7 @@ class SandboxV2Pool:
             members=info.members,
             image=info.image or image,
             runtime_class=info.runtime_class_name or "fc-host",
+            warm_state=info.warm_state,
         )
 
     @classmethod
@@ -323,6 +354,7 @@ class SandboxV2Pool:
             members=info.members,
             image=info.image,
             runtime_class=info.runtime_class_name,
+            warm_state=info.warm_state,
         )
 
     @classmethod
@@ -369,6 +401,7 @@ class SandboxV2Pool:
                         members=info.members,
                         image=info.image,
                         runtime_class=info.runtime_class_name,
+                        warm_state=info.warm_state,
                     )
                 )
         except Exception:
@@ -403,5 +436,6 @@ class SandboxV2Pool:
         return (
             f"SandboxV2Pool(name={self._name!r}, "
             f"workspace={self._workspace!r}, "
-            f"size={self._size}, ready_members={self._ready_members})"
+            f"size={self._size}, ready_members={self._ready_members}, "
+            f"warm_state={self._warm_state!r})"
         )

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -1,0 +1,392 @@
+"""SandboxV2Pool: a warm pool of pre-hibernated Firecracker sandboxes.
+
+Mirrors the v1 :class:`prokube.sandbox.SandboxPool` public surface, adapted to
+the v2 (Firecracker) backend. A pool maintains ``size`` pre-hibernated members;
+:meth:`SandboxV2.from_pool` (or :meth:`SandboxV2Pool.claim`) turns a warm member
+into a running sandbox via a fast VM resume rather than a cold boot.
+
+The pool member ``template`` is a full v2 sandbox create spec (the same knobs as
+:meth:`SandboxV2.create`); the backend forces ``runtimeClassName: fc-host`` and
+owns each member's ``operatingMode``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from prokube.common.config import Config
+from prokube.common.exceptions import SandboxError
+from prokube.sandboxv2.client import SandboxV2Client
+from prokube.sandboxv2.models import (
+    CreateSandboxV2Request,
+    HibernatedPoolMember,
+)
+
+if TYPE_CHECKING:
+    from prokube.sandboxv2.sandbox import SandboxV2
+
+
+class SandboxV2Pool:
+    """A warm pool of pre-hibernated Firecracker sandboxes.
+
+    Example:
+        >>> pool = SandboxV2Pool.create(
+        ...     name="python-pool",
+        ...     size=3,
+        ...     image="pk-sandbox-base",
+        ...     vcpus=2,
+        ...     mem_mib=2048,
+        ... )
+        >>> print(pool.name, pool.size, pool.ready_members)
+        >>>
+        >>> # Claim a warm member (fast resume)
+        >>> sbx = pool.claim()
+        >>> sbx.wait_until_ready()
+        >>>
+        >>> for p in SandboxV2Pool.list():
+        ...     print(f"{p.name}: {p.ready_members}/{p.size}")
+        >>>
+        >>> pool.delete()
+    """
+
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        client: SandboxV2Client,
+        size: int = 0,
+        ready_members: int = 0,
+        members: list[HibernatedPoolMember] | None = None,
+        image: str | None = None,
+        runtime_class: str | None = None,
+    ) -> None:
+        """Initialize a SandboxV2Pool instance.
+
+        Note: use :meth:`create`, :meth:`get`, or :meth:`list` instead of the
+        constructor.
+        """
+        self._name = name
+        self._namespace = namespace
+        self._client = client
+        self._size = size
+        self._ready_members = ready_members
+        self._members = members or []
+        self._image = image
+        self._runtime_class = runtime_class
+        self._deleted = False
+
+    @property
+    def name(self) -> str:
+        """The pool name."""
+        return self._name
+
+    @property
+    def namespace(self) -> str:
+        """The Kubernetes namespace (v1's ``workspace``)."""
+        return self._namespace
+
+    @property
+    def size(self) -> int:
+        """Desired number of warm members (spec.size)."""
+        return self._size
+
+    @property
+    def ready_members(self) -> int:
+        """Number of claimable warm members (status.readyMembers)."""
+        return self._ready_members
+
+    @property
+    def members(self) -> list[HibernatedPoolMember]:
+        """Current pool members (status.members)."""
+        return self._members
+
+    @property
+    def image(self) -> str | None:
+        """The template base OCI image."""
+        return self._image
+
+    @property
+    def runtime_class(self) -> str | None:
+        """The template runtime class (always ``fc-host`` for pools)."""
+        return self._runtime_class
+
+    def _check_not_deleted(self) -> None:
+        if self._deleted:
+            raise SandboxError(f"Pool '{self._name}' has been deleted")
+
+    def close(self) -> None:
+        """Close the underlying HTTP client without deleting the pool."""
+        self._client.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self.close()
+        return False
+
+    def delete(self) -> None:
+        """Delete this pool (idempotent). The object should not be reused."""
+        if self._deleted:
+            return
+        self._client.delete_pool(self._name)
+        self._deleted = True
+        self._client.close()
+
+    def refresh(self) -> None:
+        """Refresh pool information from the API."""
+        self._check_not_deleted()
+        info = self._client.get_pool(self._name)
+        self._size = info.size
+        self._ready_members = info.ready_members
+        self._members = info.members
+        self._image = info.image
+        self._runtime_class = info.runtime_class_name
+
+    def claim(self) -> SandboxV2:
+        """Claim a ready member from this pool (fast resume, not cold boot).
+
+        Returns:
+            A :class:`SandboxV2` bound to the claimed member. Call
+            ``wait_until_ready()`` before use.
+
+        Raises:
+            SandboxError: If the pool has no ready member to claim (HTTP 409).
+        """
+        # Imported lazily to avoid a circular import (sandbox imports nothing
+        # from pool at module load, but pool binds a SandboxV2 here).
+        from prokube.sandboxv2.sandbox import SandboxV2
+
+        self._check_not_deleted()
+        # Each claimed sandbox owns its own client so the pool's client (and
+        # other claimed sandboxes) survive when one sandbox is killed.
+        client = SandboxV2Client(self._client.config, check_version=False)
+        try:
+            info = client.claim(self._name)
+        except Exception:
+            client.close()
+            raise
+        return SandboxV2(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            status=info.status,
+            image=info.image,
+            runtime_class=info.runtime_class,
+        )
+
+    # -- constructors ---------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        size: int,
+        image: str | None = None,
+        *,
+        resources: dict | None = None,
+        vcpus: int | None = None,
+        mem_mib: int | None = None,
+        egress: bool = False,
+        terminal: bool = True,
+        volumes: list[dict] | None = None,
+        volume_mounts: list[dict] | None = None,
+        image_pull_secrets: list[str] | None = None,
+        workspace_size: str | None = None,
+        target_node: str | None = None,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> Self:
+        """Create a new warm pool of pre-hibernated Firecracker sandboxes.
+
+        Args:
+            name: Pool name.
+            size: Desired number of warm (pre-hibernated) members.
+            image: Base OCI image for members (defaults to pk-sandbox-base).
+            resources: ``{"vcpus": int, "mem_mib": int}`` shorthand.
+            vcpus: Guest vCPUs (overrides ``resources['vcpus']``).
+            mem_mib: Guest memory in MiB (overrides ``resources['mem_mib']``).
+            egress: Whether members may reach the cluster/internet.
+            terminal: Inject a ttyd Terminal into members.
+            volumes: ``spec.volumes`` pass-through (CR-shaped dicts).
+            volume_mounts: ``spec.volumeMounts`` pass-through (CR-shaped dicts).
+            image_pull_secrets: Registry pull secret names.
+            workspace_size: Ephemeral /workspace volume size (e.g. "10Gi").
+            target_node: Pin members to a node.
+            namespace: Kubernetes namespace (maps to v1's ``workspace``).
+            api_url / user_id / api_key / timeout: Connection overrides.
+
+        Note: pools are ``fc-host`` only; the backend forces the member template
+        to ``runtimeClassName: fc-host`` and owns ``operatingMode``.
+        """
+        if resources:
+            vcpus = vcpus if vcpus is not None else resources.get("vcpus")
+            mem_mib = mem_mib if mem_mib is not None else resources.get("mem_mib")
+
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        # The template's own name is ignored by the backend (members are named
+        # by the controller); reuse the pool name to satisfy validation.
+        template = CreateSandboxV2Request(
+            name=name,
+            image=image,
+            runtime_class_name="fc-host",
+            vcpus=vcpus,
+            mem_mib=mem_mib,
+            egress=egress,
+            terminal=terminal,
+            volumes=volumes,
+            volume_mounts=volume_mounts,
+            image_pull_secrets=image_pull_secrets,
+            workspace_size=workspace_size,
+            target_node=target_node,
+        )
+        client = SandboxV2Client(config)
+        try:
+            info = client.create_pool(name=name, size=size, template=template)
+        except Exception:
+            client.close()
+            raise
+
+        return cls(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            size=info.size,
+            ready_members=info.ready_members,
+            members=info.members,
+            image=info.image or image,
+            runtime_class=info.runtime_class_name or "fc-host",
+        )
+
+    @classmethod
+    def get(
+        cls,
+        name: str,
+        *,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> Self:
+        """Get an existing warm pool by name."""
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            info = client.get_pool(name)
+        except Exception:
+            client.close()
+            raise
+
+        return cls(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            size=info.size,
+            ready_members=info.ready_members,
+            members=info.members,
+            image=info.image,
+            runtime_class=info.runtime_class_name,
+        )
+
+    @classmethod
+    def list(
+        cls,
+        *,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> list[Self]:
+        """List all warm pools in the namespace."""
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            infos = client.list_pools()
+        except Exception:
+            client.close()
+            raise
+        client.close()
+
+        if not infos:
+            return []
+
+        # Each pool gets its own client so delete() on one does not invalidate
+        # the others. Skip version checks (verified earlier where applicable).
+        pools: list[Self] = []
+        try:
+            for info in infos:
+                pools.append(
+                    cls(
+                        name=info.name,
+                        namespace=info.namespace,
+                        client=SandboxV2Client(config, check_version=False),
+                        size=info.size,
+                        ready_members=info.ready_members,
+                        members=info.members,
+                        image=info.image,
+                        runtime_class=info.runtime_class_name,
+                    )
+                )
+        except Exception:
+            for p in pools:
+                p._client.close()
+            raise
+        return pools
+
+    @staticmethod
+    def _build_config(
+        api_url: str | None,
+        namespace: str | None,
+        user_id: str | None,
+        api_key: str | None,
+        timeout: int | None,
+    ) -> Config:
+        """Build configuration, mapping ``namespace`` to Config.workspace."""
+        kwargs: dict = {}
+        if api_url is not None:
+            kwargs["api_url"] = api_url
+        if namespace is not None:
+            kwargs["workspace"] = namespace
+        if user_id is not None:
+            kwargs["user_id"] = user_id
+        if api_key is not None:
+            kwargs["api_key"] = api_key
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        return Config(**kwargs)
+
+    def __repr__(self) -> str:
+        return (
+            f"SandboxV2Pool(name={self._name!r}, "
+            f"namespace={self._namespace!r}, "
+            f"size={self._size}, ready_members={self._ready_members})"
+        )

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -239,6 +239,7 @@ class SandboxV2Pool:
         lifecycle: Lifecycle | dict | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict | None = None,
+        mesh: bool | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -285,6 +286,8 @@ class SandboxV2Pool:
             dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
                 options) baked into every member template. A
                 :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
+            mesh: Optional: opt every member template into the Istio service
+                mesh (spec.mesh).
             workspace: Workspace / Kubernetes namespace (default:
                 PROKUBE_WORKSPACE env var).
             api_url / user_id / api_key / timeout: Connection overrides.
@@ -324,6 +327,7 @@ class SandboxV2Pool:
             lifecycle=lifecycle,
             dns_policy=dns_policy,
             dns_config=dns_config,
+            mesh=mesh,
         )
         client = SandboxV2Client(config)
         try:

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -26,6 +26,8 @@ from prokube.sandboxv2.client import SandboxV2Client
 from prokube.sandboxv2.models import (
     CreateSandboxV2Request,
     HibernatedPoolMember,
+    Lifecycle,
+    Probe,
 )
 
 if TYPE_CHECKING:
@@ -232,6 +234,8 @@ class SandboxV2Pool:
         image_pull_secrets: list[str] | None = None,
         workspace_size: str | None = None,
         target_node: str | None = None,
+        startup_probe: Probe | dict | None = None,
+        lifecycle: Lifecycle | dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -262,6 +266,15 @@ class SandboxV2Pool:
             image_pull_secrets: Registry pull secret names.
             workspace_size: Ephemeral /workspace volume size (e.g. "10Gi").
             target_node: Pin members to a node.
+            startup_probe: spec.startupProbe (core/v1 Probe) baked into every
+                member template — gates each member's boot readiness. A
+                :class:`~prokube.sandboxv2.models.Probe` or a CR-shaped dict.
+                Omitted -> backend execd default.
+            lifecycle: spec.lifecycle (core/v1 Lifecycle; ``postStart`` warm-up
+                hook) baked into every member template — runs before hibernate so
+                its effect rides the resumable snapshot. A
+                :class:`~prokube.sandboxv2.models.Lifecycle` or a CR-shaped dict.
+                Omitted -> backend execd default.
             workspace: Workspace / Kubernetes namespace (default:
                 PROKUBE_WORKSPACE env var).
             api_url / user_id / api_key / timeout: Connection overrides.
@@ -297,6 +310,8 @@ class SandboxV2Pool:
             image_pull_secrets=image_pull_secrets,
             workspace_size=workspace_size,
             target_node=target_node,
+            startup_probe=startup_probe,
+            lifecycle=lifecycle,
         )
         client = SandboxV2Client(config)
         try:

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -239,6 +239,7 @@ class SandboxV2Pool:
         lifecycle: Lifecycle | dict | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict | None = None,
+        snapshot_resume_policy: str | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
         user_id: str | None = None,
@@ -285,6 +286,10 @@ class SandboxV2Pool:
             dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
                 options) baked into every member template. A
                 :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
+            snapshot_resume_policy: spec.snapshotResumePolicy (``Strict`` |
+                ``AllowStale``) baked into every member template — whether
+                resuming a member's snapshot requires an exact recipe/base
+                match. Omitted -> executor Strict default.
             workspace: Workspace / Kubernetes namespace (default:
                 PROKUBE_WORKSPACE env var).
             api_url / user_id / api_key / timeout: Connection overrides.
@@ -324,6 +329,7 @@ class SandboxV2Pool:
             lifecycle=lifecycle,
             dns_policy=dns_policy,
             dns_config=dns_config,
+            snapshot_resume_policy=snapshot_resume_policy,
         )
         client = SandboxV2Client(config)
         try:

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -195,6 +195,8 @@ class SandboxV2Pool:
         mem_mib: int | None = None,
         egress: bool = False,
         terminal: bool = True,
+        env_vars: dict[str, str] | list[dict[str, str]] | None = None,
+        secret_refs: list[str] | None = None,
         volumes: list[dict] | None = None,
         volume_mounts: list[dict] | None = None,
         image_pull_secrets: list[str] | None = None,
@@ -217,6 +219,11 @@ class SandboxV2Pool:
             mem_mib: Guest memory in MiB (overrides ``resources['mem_mib']``).
             egress: Whether members may reach the cluster/internet.
             terminal: Inject a ttyd Terminal into members.
+            env_vars: Literal env vars baked into each member. Accepts a
+                ``dict[str,str]`` or a list of ``{"name","value"}`` dicts;
+                serializes to the template's CRD ``spec.env``.
+            secret_refs: Names of Secrets whose keys are injected as env vars
+                into each member; serializes to the template's ``spec.envFrom``.
             volumes: ``spec.volumes`` pass-through (CR-shaped dicts).
             volume_mounts: ``spec.volumeMounts`` pass-through (CR-shaped dicts).
             image_pull_secrets: Registry pull secret names.
@@ -249,6 +256,8 @@ class SandboxV2Pool:
             mem_mib=mem_mib,
             egress=egress,
             terminal=terminal,
+            env=env_vars,
+            env_from=secret_refs,
             volumes=volumes,
             volume_mounts=volume_mounts,
             image_pull_secrets=image_pull_secrets,

--- a/src/prokube/sandboxv2/pool.py
+++ b/src/prokube/sandboxv2/pool.py
@@ -58,7 +58,7 @@ class SandboxV2Pool:
     def __init__(
         self,
         name: str,
-        namespace: str,
+        workspace: str,
         client: SandboxV2Client,
         size: int = 0,
         ready_members: int = 0,
@@ -72,7 +72,7 @@ class SandboxV2Pool:
         constructor.
         """
         self._name = name
-        self._namespace = namespace
+        self._workspace = workspace
         self._client = client
         self._size = size
         self._ready_members = ready_members
@@ -87,9 +87,14 @@ class SandboxV2Pool:
         return self._name
 
     @property
+    def workspace(self) -> str:
+        """The workspace (Kubernetes namespace)."""
+        return self._workspace
+
+    @property
     def namespace(self) -> str:
-        """The Kubernetes namespace (v1's ``workspace``)."""
-        return self._namespace
+        """Deprecated alias for :attr:`workspace` (v1 uses ``workspace``)."""
+        return self._workspace
 
     @property
     def size(self) -> int:
@@ -174,7 +179,7 @@ class SandboxV2Pool:
             raise
         return SandboxV2(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             status=info.status,
             image=info.image,
@@ -202,8 +207,8 @@ class SandboxV2Pool:
         image_pull_secrets: list[str] | None = None,
         workspace_size: str | None = None,
         target_node: str | None = None,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
@@ -229,7 +234,8 @@ class SandboxV2Pool:
             image_pull_secrets: Registry pull secret names.
             workspace_size: Ephemeral /workspace volume size (e.g. "10Gi").
             target_node: Pin members to a node.
-            namespace: Kubernetes namespace (maps to v1's ``workspace``).
+            workspace: Workspace / Kubernetes namespace (default:
+                PROKUBE_WORKSPACE env var).
             api_url / user_id / api_key / timeout: Connection overrides.
 
         Note: pools are ``fc-host`` only; the backend forces the member template
@@ -241,7 +247,7 @@ class SandboxV2Pool:
 
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -273,7 +279,7 @@ class SandboxV2Pool:
 
         return cls(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             size=info.size,
             ready_members=info.ready_members,
@@ -287,8 +293,8 @@ class SandboxV2Pool:
         cls,
         name: str,
         *,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
@@ -296,7 +302,7 @@ class SandboxV2Pool:
         """Get an existing warm pool by name."""
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -310,7 +316,7 @@ class SandboxV2Pool:
 
         return cls(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             size=info.size,
             ready_members=info.ready_members,
@@ -323,16 +329,16 @@ class SandboxV2Pool:
     def list(
         cls,
         *,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
     ) -> list[Self]:
-        """List all warm pools in the namespace."""
+        """List all warm pools in the workspace."""
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -356,7 +362,7 @@ class SandboxV2Pool:
                 pools.append(
                     cls(
                         name=info.name,
-                        namespace=info.namespace,
+                        workspace=info.workspace,
                         client=SandboxV2Client(config, check_version=False),
                         size=info.size,
                         ready_members=info.ready_members,
@@ -374,17 +380,17 @@ class SandboxV2Pool:
     @staticmethod
     def _build_config(
         api_url: str | None,
-        namespace: str | None,
+        workspace: str | None,
         user_id: str | None,
         api_key: str | None,
         timeout: int | None,
     ) -> Config:
-        """Build configuration, mapping ``namespace`` to Config.workspace."""
+        """Build configuration from explicit params and environment."""
         kwargs: dict = {}
         if api_url is not None:
             kwargs["api_url"] = api_url
-        if namespace is not None:
-            kwargs["workspace"] = namespace
+        if workspace is not None:
+            kwargs["workspace"] = workspace
         if user_id is not None:
             kwargs["user_id"] = user_id
         if api_key is not None:
@@ -396,6 +402,6 @@ class SandboxV2Pool:
     def __repr__(self) -> str:
         return (
             f"SandboxV2Pool(name={self._name!r}, "
-            f"namespace={self._namespace!r}, "
+            f"workspace={self._workspace!r}, "
             f"size={self._size}, ready_members={self._ready_members})"
         )

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -143,18 +143,24 @@ class SandboxV2:
         language: str = "python",
         timeout: int = 300,
     ) -> CodeResult:
-        """Execute code in the guest Jupyter kernel (stateful)."""
+        """Execute code in the guest's persistent per-language session (stateful).
+
+        SandboxV2 runs the curated sandbox-agent, which keeps one long-lived
+        interpreter per language (python/bash/node) — variables, imports and
+        shell state persist across calls and survive pause/resume. (There is no
+        Jupyter kernel; that was the old execd image.)"""
         self._check_not_killed()
         return self._code.run(code, language=language, timeout=timeout)
 
     def reset_session(self) -> None:
-        """Reset the Jupyter kernel session for the next ``run_code``."""
+        """Restart the guest's per-language interpreter session, clearing its
+        state for the next ``run_code`` (maps to the agent's ``context.reset``)."""
         self._check_not_killed()
         self._code.reset_session()
 
     @property
     def session_id(self) -> str | None:
-        """Current Jupyter session ID, if any."""
+        """Current guest interpreter session ID, if any."""
         return self._code.session_id
 
     def pause(self) -> None:
@@ -208,6 +214,10 @@ class SandboxV2:
             SandboxError: If it enters the Failed terminal state while waiting.
         """
         self._check_not_killed()
+        # Fast path: a pool-hot (warmState=Running) member is handed over already
+        # Running, so skip the readiness round-trip entirely.
+        if self._status == SandboxV2Status.RUNNING:
+            return
         deadline = time.monotonic() + timeout
         use_long_poll = True
         # Local-poll fallback cadence: start tight (matches the ~0.4s
@@ -539,9 +549,9 @@ class SandboxV2:
         swapping ``Sandbox`` for ``SandboxV2`` needs no other change. Claims a
         pre-hibernated member from a
         :class:`~prokube.sandboxv2.pool.SandboxV2Pool` and returns a SandboxV2
-        bound to it. A claim is a fast VM resume (~1.4s), so unlike
-        :meth:`create` the returned sandbox is (or is quickly becoming) Running
-        — call :meth:`wait_until_ready` to be sure before use.
+        bound to it. A claim is a fast VM resume (~1.4s); ``from_pool`` waits
+        for the member to reach Running (via :meth:`wait_until_ready`) before
+        returning, so the sandbox is ready to use immediately.
 
         Args:
             pool: Name of the warm pool to claim from.
@@ -580,7 +590,7 @@ class SandboxV2:
             client.close()
             raise
 
-        return cls(
+        sbx = cls(
             name=info.name,
             workspace=info.workspace,
             client=client,
@@ -588,6 +598,19 @@ class SandboxV2:
             image=info.image,
             runtime_class=info.runtime_class,
         )
+        # Hand back a ready-to-use sandbox. A claim flips a Hibernated member to
+        # Running (a ~1.4s VM resume); wait_until_ready gates on that via the
+        # backend's server-side readiness long-poll. A pool-hot (warmState=Running)
+        # member is already Running, so this returns immediately (see the
+        # short-circuit in wait_until_ready). No guest-kernel probing/reset: the
+        # curated sandbox-agent's per-language session survives the snapshot, so
+        # once the VM is Running the session is intact.
+        try:
+            sbx.wait_until_ready()
+        except Exception:
+            client.close()
+            raise
+        return sbx
 
     @staticmethod
     def _build_config(

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -237,6 +237,8 @@ class SandboxV2:
         mem_mib: int | None = None,
         egress: bool = False,
         terminal: bool = True,
+        env_vars: dict[str, str] | list[dict[str, str]] | None = None,
+        secret_refs: list[str] | None = None,
         volumes: list[dict] | None = None,
         volume_mounts: list[dict] | None = None,
         image_pull_secrets: list[str] | None = None,
@@ -265,6 +267,11 @@ class SandboxV2:
             egress: Whether the microVM may reach the cluster/internet
                 (default: False — isolated).
             terminal: Inject a ttyd Terminal (:7681) into the guest.
+            env_vars: Literal env vars baked into the guest. Accepts a
+                ``dict[str,str]`` or a list of ``{"name","value"}`` dicts;
+                serializes to CRD ``spec.env``. Not refreshed on pause/resume.
+            secret_refs: Names of Secrets (in the sandbox namespace) whose keys
+                are injected as env vars; serializes to CRD ``spec.envFrom``.
             volumes: ``spec.volumes`` pass-through (CR-shaped dicts).
             volume_mounts: ``spec.volumeMounts`` pass-through (CR-shaped dicts).
             image_pull_secrets: Registry pull secret names.
@@ -302,6 +309,8 @@ class SandboxV2:
                 mem_mib=mem_mib,
                 egress=egress,
                 terminal=terminal,
+                env_vars=env_vars,
+                secret_refs=secret_refs,
                 volumes=volumes,
                 volume_mounts=volume_mounts,
                 image_pull_secrets=image_pull_secrets,

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -23,7 +23,11 @@ else:
     from typing_extensions import Self
 
 from prokube.common.config import Config
-from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.common.exceptions import (
+    NotFoundError,
+    SandboxError,
+    SandboxTimeoutError,
+)
 from prokube.sandbox.code import CodeRunner
 from prokube.sandbox.commands import CommandRunner
 from prokube.sandbox.files import FileManager
@@ -177,6 +181,13 @@ class SandboxV2:
     def wait_until_ready(self, timeout: int = 120) -> None:
         """Block until the sandbox phase is Running.
 
+        A ready microVM resumes in well under a second, so this prefers the
+        backend's server-side long-poll readiness endpoint (a single request the
+        backend resolves in-cluster the instant ``status.phase`` flips to
+        Running) and otherwise falls back to a tight local ``get`` poll (~100ms,
+        gently backing off to 1s). Both paths supersede the old flat 2s poll that
+        quantized a sub-second resume into multi-second waits.
+
         Args:
             timeout: Maximum seconds to wait (default: 120).
 
@@ -185,9 +196,48 @@ class SandboxV2:
             SandboxError: If it enters the Failed terminal state while waiting.
         """
         self._check_not_killed()
-        poll_interval = 2
         deadline = time.monotonic() + timeout
+        use_long_poll = True
+        # Local-poll fallback cadence: start tight (matches the ~0.4s
+        # control-plane lag) and back off so a slow-to-ready sandbox does not
+        # hammer the backend for the full timeout window.
+        poll_interval = 0.1
+
         while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+
+            if use_long_poll:
+                try:
+                    # Server long-polls up to its own window; loop here until our
+                    # deadline. Cap each call so a stalled connection still
+                    # rechecks our timeout periodically.
+                    info = self._client.wait_ready(
+                        self._name, timeout=min(int(remaining) + 1, 30)
+                    )
+                except NotFoundError:
+                    # Endpoint absent (older backend) or sandbox genuinely
+                    # missing: drop to the local poll, which re-raises the real
+                    # not-found error if the sandbox truly does not exist.
+                    use_long_poll = False
+                    continue
+                self._status = info.status
+                if info.runtime_class is not None:
+                    self._runtime_class = info.runtime_class
+                if info.image is not None:
+                    self._image = info.image
+                if self._status == SandboxV2Status.RUNNING:
+                    return
+                if self._status == SandboxV2Status.FAILED:
+                    raise SandboxError(
+                        f"Sandbox {self._name} entered terminal state "
+                        f"{self._status.value!r} while waiting for it to become "
+                        f"ready"
+                    )
+                # Server-side timeout below Running: loop (re-checks deadline).
+                continue
+
             self.refresh()
             if self._status == SandboxV2Status.RUNNING:
                 return
@@ -200,6 +250,8 @@ class SandboxV2:
             if remaining <= 0:
                 break
             time.sleep(min(poll_interval, remaining))
+            poll_interval = min(poll_interval * 1.5, 1.0)
+
         raise SandboxTimeoutError(
             f"Sandbox {self._name} did not become ready within {timeout}s "
             f"(current phase: {self._status.value!r})"

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -33,7 +33,12 @@ from prokube.sandbox.commands import CommandRunner
 from prokube.sandbox.files import FileManager
 from prokube.sandbox.models import CodeResult
 from prokube.sandboxv2.client import SandboxV2Client
-from prokube.sandboxv2.models import Lifecycle, Probe, SandboxV2Status
+from prokube.sandboxv2.models import (
+    DNSConfig,
+    Lifecycle,
+    Probe,
+    SandboxV2Status,
+)
 
 
 class SandboxV2:
@@ -304,6 +309,8 @@ class SandboxV2:
         operating_mode: str | None = None,
         startup_probe: Probe | dict | None = None,
         lifecycle: Lifecycle | dict | None = None,
+        dns_policy: str | None = None,
+        dns_config: DNSConfig | dict | None = None,
         manifest: dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
@@ -343,6 +350,12 @@ class SandboxV2:
             lifecycle: spec.lifecycle (core/v1 Lifecycle; ``postStart`` warm-up
                 hook). A :class:`~prokube.sandboxv2.models.Lifecycle` or a
                 CR-shaped dict. Omitted -> backend execd default.
+            dns_policy: spec.dnsPolicy (``ClusterFirst`` | ``None`` | ``Default``)
+                — how the guest /etc/resolv.conf is written at cold boot.
+                Omitted -> executor ClusterFirst default.
+            dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
+                options merged into the guest resolv.conf). A
+                :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
             manifest: Full FirecrackerSandbox object; wins over structured knobs.
             api_url: API URL (default: PROKUBE_API_URL env var).
             workspace: Workspace / Kubernetes namespace (default:
@@ -385,6 +398,8 @@ class SandboxV2:
                 operating_mode=operating_mode,
                 startup_probe=startup_probe,
                 lifecycle=lifecycle,
+                dns_policy=dns_policy,
+                dns_config=dns_config,
                 manifest=manifest,
             )
         except Exception:

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import sys
 import time
 
+import httpx
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -230,13 +232,15 @@ class SandboxV2:
             if remaining <= 0:
                 break
 
-            if use_long_poll:
+            if use_long_poll and remaining >= 1:
                 try:
-                    # Server long-polls up to its own window; loop here until our
-                    # deadline. Cap each call so a stalled connection still
-                    # rechecks our timeout periodically.
+                    # Server long-polls up to its own window, while the HTTP
+                    # request itself is bounded by the caller's remaining
+                    # readiness budget.
                     info = self._client.wait_ready(
-                        self._name, timeout=min(int(remaining) + 1, 30)
+                        self._name,
+                        timeout=min(int(remaining), 30),
+                        request_timeout=remaining,
                     )
                 except NotFoundError:
                     # Endpoint absent (older backend) or sandbox genuinely
@@ -244,6 +248,8 @@ class SandboxV2:
                     # not-found error if the sandbox truly does not exist.
                     use_long_poll = False
                     continue
+                except httpx.TimeoutException:
+                    break
                 self._status = info.status
                 if info.runtime_class is not None:
                     self._runtime_class = info.runtime_class
@@ -260,7 +266,10 @@ class SandboxV2:
                 # Server-side timeout below Running: loop (re-checks deadline).
                 continue
 
-            self.refresh()
+            try:
+                self.refresh(request_timeout=remaining)
+            except httpx.TimeoutException:
+                break
             if self._status == SandboxV2Status.RUNNING:
                 return
             if self._status == SandboxV2Status.FAILED:
@@ -292,10 +301,10 @@ class SandboxV2:
         self._killed = True
         self._client.close()
 
-    def refresh(self) -> None:
+    def refresh(self, request_timeout: float | None = None) -> None:
         """Refresh sandbox information from the API."""
         self._check_not_killed()
-        info = self._client.get(self._name)
+        info = self._client.get(self._name, request_timeout=request_timeout)
         self._status = info.status
         if info.runtime_class is not None:
             self._runtime_class = info.runtime_class

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -311,6 +311,7 @@ class SandboxV2:
         lifecycle: Lifecycle | dict | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict | None = None,
+        mesh: bool | None = None,
         manifest: dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
@@ -356,6 +357,8 @@ class SandboxV2:
             dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
                 options merged into the guest resolv.conf). A
                 :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
+            mesh: Optional: opt this sandbox into the Istio service mesh
+                (spec.mesh).
             manifest: Full FirecrackerSandbox object; wins over structured knobs.
             api_url: API URL (default: PROKUBE_API_URL env var).
             workspace: Workspace / Kubernetes namespace (default:
@@ -400,6 +403,7 @@ class SandboxV2:
                 lifecycle=lifecycle,
                 dns_policy=dns_policy,
                 dns_config=dns_config,
+                mesh=mesh,
                 manifest=manifest,
             )
         except Exception:

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -3,7 +3,8 @@
 Mirrors the v1 :class:`prokube.sandbox.Sandbox` public surface, adapted to the
 v2 backend: creation takes a ``runtime_class`` (``fc-host`` / ``fc-pod``) and v2
 knobs (resources, egress, volumes), v1's ``workspace`` maps to ``namespace``,
-and there is no warm pool (``from_pool`` raises ``NotImplementedError``).
+and the warm pool is a FirecrackerHibernatedPool (:meth:`SandboxV2.from_pool`
+claims a pre-hibernated member; see :class:`prokube.sandboxv2.pool.SandboxV2Pool`).
 
 The stateful code / shell command / file helpers are the *same* v1 classes
 (:class:`CodeRunner` / :class:`CommandRunner` / :class:`FileManager`) — they are
@@ -412,15 +413,64 @@ class SandboxV2:
         return sandboxes
 
     @classmethod
-    def from_pool(cls, *args: object, **kwargs: object) -> Self:
-        """Not supported on v2. Sandbox v2 (Firecracker) has no warm pool.
+    def from_pool(
+        cls,
+        pool: str,
+        *,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> Self:
+        """Claim a ready member from a warm pool (fast resume, not cold boot).
 
-        Warm-pool parity is a known future item (see the SANDBOXV2_V1_PARITY
-        doc). Use :meth:`create` + :meth:`wait_until_ready` instead.
+        Claims a pre-hibernated member from a
+        :class:`~prokube.sandboxv2.pool.SandboxV2Pool` and returns a SandboxV2
+        bound to it. A claim is a fast VM resume (~1.4s), so unlike
+        :meth:`create` the returned sandbox is (or is quickly becoming) Running
+        — call :meth:`wait_until_ready` to be sure before use.
+
+        Args:
+            pool: Name of the warm pool to claim from.
+            namespace: Kubernetes namespace (maps to v1's ``workspace``).
+            api_url: API URL (default: PROKUBE_API_URL env var).
+            user_id: User ID (default: PROKUBE_USER_ID env var).
+            api_key: API key (default: PROKUBE_API_KEY env var).
+            timeout: Request timeout (default: PROKUBE_TIMEOUT env var).
+
+        Returns:
+            A SandboxV2 instance bound to the claimed member.
+
+        Raises:
+            SandboxError: If the pool has no ready member to claim (HTTP 409).
+
+        Example:
+            >>> sbx = SandboxV2.from_pool("python-pool")
+            >>> sbx.wait_until_ready()
+            >>> sbx.run_code("print('hello')")
         """
-        raise NotImplementedError(
-            "Sandbox v2 (Firecracker) has no warm pool. `from_pool` is a future "
-            "parity item; use SandboxV2.create() + wait_until_ready() instead."
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            info = client.claim(pool)
+        except Exception:
+            client.close()
+            raise
+
+        return cls(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            status=info.status,
+            image=info.image,
+            runtime_class=info.runtime_class,
         )
 
     @staticmethod

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -311,6 +311,7 @@ class SandboxV2:
         lifecycle: Lifecycle | dict | None = None,
         dns_policy: str | None = None,
         dns_config: DNSConfig | dict | None = None,
+        snapshot_resume_policy: str | None = None,
         manifest: dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
@@ -356,6 +357,10 @@ class SandboxV2:
             dns_config: spec.dnsConfig (Pod PodDNSConfig — nameservers/searches/
                 options merged into the guest resolv.conf). A
                 :class:`~prokube.sandboxv2.models.DNSConfig` or a CR-shaped dict.
+            snapshot_resume_policy: spec.snapshotResumePolicy (``Strict`` |
+                ``AllowStale``) — whether resuming from a pool member's
+                snapshot requires an exact recipe/base match. Omitted ->
+                executor Strict default.
             manifest: Full FirecrackerSandbox object; wins over structured knobs.
             api_url: API URL (default: PROKUBE_API_URL env var).
             workspace: Workspace / Kubernetes namespace (default:
@@ -400,6 +405,7 @@ class SandboxV2:
                 lifecycle=lifecycle,
                 dns_policy=dns_policy,
                 dns_config=dns_config,
+                snapshot_resume_policy=snapshot_resume_policy,
                 manifest=manifest,
             )
         except Exception:

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -33,7 +33,7 @@ from prokube.sandbox.commands import CommandRunner
 from prokube.sandbox.files import FileManager
 from prokube.sandbox.models import CodeResult
 from prokube.sandboxv2.client import SandboxV2Client
-from prokube.sandboxv2.models import SandboxV2Status
+from prokube.sandboxv2.models import Lifecycle, Probe, SandboxV2Status
 
 
 class SandboxV2:
@@ -302,6 +302,8 @@ class SandboxV2:
         workspace_size: str | None = None,
         target_node: str | None = None,
         operating_mode: str | None = None,
+        startup_probe: Probe | dict | None = None,
+        lifecycle: Lifecycle | dict | None = None,
         manifest: dict | None = None,
         api_url: str | None = None,
         workspace: str | None = None,
@@ -335,6 +337,12 @@ class SandboxV2:
             workspace_size: Default ephemeral /workspace size (e.g. "10Gi").
             target_node: Pin the microVM to a node.
             operating_mode: ``Running`` or ``Hibernated``.
+            startup_probe: spec.startupProbe (core/v1 Probe) gating boot
+                readiness. A :class:`~prokube.sandboxv2.models.Probe` or a
+                CR-shaped dict. Omitted -> backend execd default.
+            lifecycle: spec.lifecycle (core/v1 Lifecycle; ``postStart`` warm-up
+                hook). A :class:`~prokube.sandboxv2.models.Lifecycle` or a
+                CR-shaped dict. Omitted -> backend execd default.
             manifest: Full FirecrackerSandbox object; wins over structured knobs.
             api_url: API URL (default: PROKUBE_API_URL env var).
             workspace: Workspace / Kubernetes namespace (default:
@@ -375,6 +383,8 @@ class SandboxV2:
                 workspace_size=workspace_size,
                 target_node=target_node,
                 operating_mode=operating_mode,
+                startup_probe=startup_probe,
+                lifecycle=lifecycle,
                 manifest=manifest,
             )
         except Exception:

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -2,8 +2,8 @@
 
 Mirrors the v1 :class:`prokube.sandbox.Sandbox` public surface, adapted to the
 v2 backend: creation takes a ``runtime_class`` (``fc-host`` / ``fc-pod``) and v2
-knobs (resources, egress, volumes), v1's ``workspace`` maps to ``namespace``,
-and the warm pool is a FirecrackerHibernatedPool (:meth:`SandboxV2.from_pool`
+knobs (resources, egress, volumes), the same ``workspace`` param as v1, and the
+warm pool is a FirecrackerHibernatedPool (:meth:`SandboxV2.from_pool`
 claims a pre-hibernated member; see :class:`prokube.sandboxv2.pool.SandboxV2Pool`).
 
 The stateful code / shell command / file helpers are the *same* v1 classes
@@ -57,7 +57,7 @@ class SandboxV2:
     def __init__(
         self,
         name: str,
-        namespace: str,
+        workspace: str,
         client: SandboxV2Client,
         status: SandboxV2Status = SandboxV2Status.PENDING,
         image: str | None = None,
@@ -68,7 +68,7 @@ class SandboxV2:
         Note: use :meth:`create` or :meth:`get` instead of the constructor.
         """
         self._name = name
-        self._namespace = namespace
+        self._workspace = workspace
         self._client = client
         self._status = status
         self._image = image
@@ -91,9 +91,14 @@ class SandboxV2:
         return self._name
 
     @property
+    def workspace(self) -> str:
+        """The workspace (Kubernetes namespace)."""
+        return self._workspace
+
+    @property
     def namespace(self) -> str:
-        """The Kubernetes namespace."""
-        return self._namespace
+        """Deprecated alias for :attr:`workspace` (v1 uses ``workspace``)."""
+        return self._workspace
 
     @property
     def runtime_class(self) -> str | None:
@@ -246,8 +251,8 @@ class SandboxV2:
         target_node: str | None = None,
         operating_mode: str | None = None,
         manifest: dict | None = None,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
@@ -279,8 +284,9 @@ class SandboxV2:
             target_node: Pin the microVM to a node.
             operating_mode: ``Running`` or ``Hibernated``.
             manifest: Full FirecrackerSandbox object; wins over structured knobs.
-            namespace: Kubernetes namespace (maps to v1's ``workspace``).
             api_url: API URL (default: PROKUBE_API_URL env var).
+            workspace: Workspace / Kubernetes namespace (default:
+                PROKUBE_WORKSPACE env var).
             user_id: User ID (default: PROKUBE_USER_ID env var).
             api_key: API key (default: PROKUBE_API_KEY env var).
             timeout: Request timeout (default: PROKUBE_TIMEOUT env var).
@@ -294,7 +300,7 @@ class SandboxV2:
 
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -325,7 +331,7 @@ class SandboxV2:
 
         return cls(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             status=info.status,
             image=info.image or image,
@@ -337,8 +343,8 @@ class SandboxV2:
         cls,
         name: str,
         *,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
@@ -346,7 +352,7 @@ class SandboxV2:
         """Connect to an existing Firecracker sandbox by name."""
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -360,7 +366,7 @@ class SandboxV2:
 
         return cls(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             status=info.status,
             image=info.image,
@@ -375,16 +381,16 @@ class SandboxV2:
         cls,
         *,
         phase: str | None = None,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
     ) -> list[Self]:
-        """List Firecracker sandboxes in the namespace."""
+        """List Firecracker sandboxes in the workspace."""
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
@@ -408,7 +414,7 @@ class SandboxV2:
                 sandboxes.append(
                     cls(
                         name=info.name,
-                        namespace=info.namespace,
+                        workspace=info.workspace,
                         client=SandboxV2Client(config, check_version=False),
                         status=info.status,
                         image=info.image,
@@ -426,15 +432,18 @@ class SandboxV2:
         cls,
         pool: str,
         *,
-        namespace: str | None = None,
         api_url: str | None = None,
+        workspace: str | None = None,
         user_id: str | None = None,
         api_key: str | None = None,
+        auto_idle_timeout_seconds: int | None = None,
         timeout: int | None = None,
     ) -> Self:
-        """Claim a ready member from a warm pool (fast resume, not cold boot).
+        """Claim a sandbox from a warm pool.
 
-        Claims a pre-hibernated member from a
+        Signature-compatible with :meth:`prokube.sandbox.Sandbox.from_pool`, so
+        swapping ``Sandbox`` for ``SandboxV2`` needs no other change. Claims a
+        pre-hibernated member from a
         :class:`~prokube.sandboxv2.pool.SandboxV2Pool` and returns a SandboxV2
         bound to it. A claim is a fast VM resume (~1.4s), so unlike
         :meth:`create` the returned sandbox is (or is quickly becoming) Running
@@ -442,10 +451,12 @@ class SandboxV2:
 
         Args:
             pool: Name of the warm pool to claim from.
-            namespace: Kubernetes namespace (maps to v1's ``workspace``).
             api_url: API URL (default: PROKUBE_API_URL env var).
+            workspace: Workspace / Kubernetes namespace (default:
+                PROKUBE_WORKSPACE env var).
             user_id: User ID (default: PROKUBE_USER_ID env var).
             api_key: API key (default: PROKUBE_API_KEY env var).
+            auto_idle_timeout_seconds: Per-claim auto-idle override in seconds.
             timeout: Request timeout (default: PROKUBE_TIMEOUT env var).
 
         Returns:
@@ -461,21 +472,23 @@ class SandboxV2:
         """
         config = cls._build_config(
             api_url=api_url,
-            namespace=namespace,
+            workspace=workspace,
             user_id=user_id,
             api_key=api_key,
             timeout=timeout,
         )
         client = SandboxV2Client(config)
         try:
-            info = client.claim(pool)
+            info = client.claim(
+                pool, auto_idle_timeout_seconds=auto_idle_timeout_seconds
+            )
         except Exception:
             client.close()
             raise
 
         return cls(
             name=info.name,
-            namespace=info.namespace,
+            workspace=info.workspace,
             client=client,
             status=info.status,
             image=info.image,
@@ -485,17 +498,17 @@ class SandboxV2:
     @staticmethod
     def _build_config(
         api_url: str | None,
-        namespace: str | None,
+        workspace: str | None,
         user_id: str | None,
         api_key: str | None,
         timeout: int | None,
     ) -> Config:
-        """Build configuration, mapping ``namespace`` to Config.workspace."""
+        """Build configuration from explicit params and environment."""
         kwargs: dict = {}
         if api_url is not None:
             kwargs["api_url"] = api_url
-        if namespace is not None:
-            kwargs["workspace"] = namespace
+        if workspace is not None:
+            kwargs["workspace"] = workspace
         if user_id is not None:
             kwargs["user_id"] = user_id
         if api_key is not None:
@@ -519,7 +532,7 @@ class SandboxV2:
     def __repr__(self) -> str:
         return (
             f"SandboxV2(name={self._name!r}, "
-            f"namespace={self._namespace!r}, "
+            f"workspace={self._workspace!r}, "
             f"runtime_class={self._runtime_class!r}, "
             f"status={self._status.value!r})"
         )

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -1,0 +1,466 @@
+"""Main SandboxV2 class for Firecracker (Sandbox v2) microVMs.
+
+Mirrors the v1 :class:`prokube.sandbox.Sandbox` public surface, adapted to the
+v2 backend: creation takes a ``runtime_class`` (``fc-host`` / ``fc-pod``) and v2
+knobs (resources, egress, volumes), v1's ``workspace`` maps to ``namespace``,
+and there is no warm pool (``from_pool`` raises ``NotImplementedError``).
+
+The stateful code / shell command / file helpers are the *same* v1 classes
+(:class:`CodeRunner` / :class:`CommandRunner` / :class:`FileManager`) — they are
+duck-typed against the client method surface, which :class:`SandboxV2Client`
+reproduces exactly.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from prokube.common.config import Config
+from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.sandbox.code import CodeRunner
+from prokube.sandbox.commands import CommandRunner
+from prokube.sandbox.files import FileManager
+from prokube.sandbox.models import CodeResult
+from prokube.sandboxv2.client import SandboxV2Client
+from prokube.sandboxv2.models import SandboxV2Status
+
+
+class SandboxV2:
+    """A Firecracker microVM sandbox for executing code and commands.
+
+    Example:
+        >>> sbx = SandboxV2.create(
+        ...     image="pk-sandbox-base",
+        ...     runtime_class="fc-host",
+        ...     resources={"vcpus": 2, "mem_mib": 2048},
+        ...     egress=False,
+        ... )
+        >>> sbx.wait_until_ready()
+        >>> print(sbx.run_code("print(2 + 2)").stdout)
+        >>> sbx.commands.run("pip install numpy")
+        >>> sbx.files.write("/workspace/x.txt", "hello")
+        >>> sbx.kill()
+
+    Context manager:
+        >>> with SandboxV2.create(image="pk-sandbox-base") as sbx:
+        ...     sbx.wait_until_ready()
+        ...     print(sbx.run_code("print(42)").stdout)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        client: SandboxV2Client,
+        status: SandboxV2Status = SandboxV2Status.PENDING,
+        image: str | None = None,
+        runtime_class: str | None = None,
+    ) -> None:
+        """Initialize a SandboxV2 instance.
+
+        Note: use :meth:`create` or :meth:`get` instead of the constructor.
+        """
+        self._name = name
+        self._namespace = namespace
+        self._client = client
+        self._status = status
+        self._image = image
+        self._runtime_class = runtime_class
+        self._killed = False
+
+        self._commands = CommandRunner(client, name, self._check_not_killed)
+        self._files = FileManager(client, name, self._check_not_killed)
+        self._code = CodeRunner(client, name, self._check_not_killed)
+
+    def _check_not_killed(self) -> None:
+        if self._killed:
+            raise SandboxError(
+                f"Sandbox {self._name} has been killed and cannot be used anymore"
+            )
+
+    @property
+    def name(self) -> str:
+        """The sandbox name."""
+        return self._name
+
+    @property
+    def namespace(self) -> str:
+        """The Kubernetes namespace."""
+        return self._namespace
+
+    @property
+    def runtime_class(self) -> str | None:
+        """The runtime class (fc-host | fc-pod)."""
+        return self._runtime_class
+
+    @property
+    def status(self) -> str:
+        """The last-known phase (does not refresh)."""
+        return self._status.value
+
+    @property
+    def phase(self) -> str:
+        """Current phase, refreshed from the API."""
+        self.refresh()
+        return self._status.value
+
+    @property
+    def commands(self) -> CommandRunner:
+        """Runner for shell commands."""
+        self._check_not_killed()
+        return self._commands
+
+    @property
+    def files(self) -> FileManager:
+        """Manager for guest file operations."""
+        self._check_not_killed()
+        return self._files
+
+    def run_code(
+        self,
+        code: str,
+        language: str = "python",
+        timeout: int = 300,
+    ) -> CodeResult:
+        """Execute code in the guest Jupyter kernel (stateful)."""
+        self._check_not_killed()
+        return self._code.run(code, language=language, timeout=timeout)
+
+    def reset_session(self) -> None:
+        """Reset the Jupyter kernel session for the next ``run_code``."""
+        self._check_not_killed()
+        self._code.reset_session()
+
+    @property
+    def session_id(self) -> str | None:
+        """Current Jupyter session ID, if any."""
+        return self._code.session_id
+
+    def pause(self) -> None:
+        """Pause the sandbox (native VM snapshot to shared storage).
+
+        Raises:
+            SandboxError: If the sandbox is not in Running state (HTTP 409).
+        """
+        self._check_not_killed()
+        info = self._client.pause(self._name)
+        self._status = (
+            info.status
+            if info.status != SandboxV2Status.UNKNOWN
+            else SandboxV2Status.PAUSED
+        )
+        self._code.reset_session()
+
+    def resume(self) -> None:
+        """Resume a paused sandbox (native VM restore).
+
+        Raises:
+            SandboxError: If the sandbox is not in Paused state (HTTP 409).
+        """
+        self._check_not_killed()
+        info = self._client.resume(self._name)
+        self._status = info.status
+        self._code.reset_session()
+
+    def wait_until_ready(self, timeout: int = 120) -> None:
+        """Block until the sandbox phase is Running.
+
+        Args:
+            timeout: Maximum seconds to wait (default: 120).
+
+        Raises:
+            SandboxTimeoutError: If it does not become Running in time.
+            SandboxError: If it enters the Failed terminal state while waiting.
+        """
+        self._check_not_killed()
+        poll_interval = 2
+        deadline = time.monotonic() + timeout
+        while True:
+            self.refresh()
+            if self._status == SandboxV2Status.RUNNING:
+                return
+            if self._status == SandboxV2Status.FAILED:
+                raise SandboxError(
+                    f"Sandbox {self._name} entered terminal state "
+                    f"{self._status.value!r} while waiting for it to become ready"
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(poll_interval, remaining))
+        raise SandboxTimeoutError(
+            f"Sandbox {self._name} did not become ready within {timeout}s "
+            f"(current phase: {self._status.value!r})"
+        )
+
+    def kill(self) -> None:
+        """Destroy the sandbox immediately.
+
+        After this the sandbox cannot be used. If the delete request fails, an
+        exception is raised and the sandbox remains usable so callers can retry.
+        """
+        if self._killed:
+            return
+        self._client.delete(self._name)
+        self._status = SandboxV2Status.UNKNOWN
+        self._killed = True
+        self._client.close()
+
+    def refresh(self) -> None:
+        """Refresh sandbox information from the API."""
+        self._check_not_killed()
+        info = self._client.get(self._name)
+        self._status = info.status
+        if info.runtime_class is not None:
+            self._runtime_class = info.runtime_class
+        if info.image is not None:
+            self._image = info.image
+
+    # -- constructors ---------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        image: str | None = None,
+        *,
+        runtime_class: str = "fc-host",
+        name: str | None = None,
+        resources: dict | None = None,
+        vcpus: int | None = None,
+        mem_mib: int | None = None,
+        egress: bool = False,
+        terminal: bool = True,
+        volumes: list[dict] | None = None,
+        volume_mounts: list[dict] | None = None,
+        image_pull_secrets: list[str] | None = None,
+        workspace_size: str | None = None,
+        target_node: str | None = None,
+        operating_mode: str | None = None,
+        manifest: dict | None = None,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> Self:
+        """Create a new Firecracker sandbox.
+
+        Args:
+            image: Base OCI image. If None, the backend default (pk-sandbox-base)
+                is used.
+            runtime_class: ``fc-host`` (VM, default) or ``fc-pod`` (pod-hosted).
+                Maps to ``spec.runtimeClassName``.
+            name: Optional sandbox name (auto-generated if not provided).
+            resources: Optional ``{"vcpus": int, "mem_mib": int}`` shorthand.
+                Explicit ``vcpus`` / ``mem_mib`` kwargs take precedence.
+            vcpus: Guest vCPUs (overrides ``resources['vcpus']``).
+            mem_mib: Guest memory in MiB (overrides ``resources['mem_mib']``).
+            egress: Whether the microVM may reach the cluster/internet
+                (default: False — isolated).
+            terminal: Inject a ttyd Terminal (:7681) into the guest.
+            volumes: ``spec.volumes`` pass-through (CR-shaped dicts).
+            volume_mounts: ``spec.volumeMounts`` pass-through (CR-shaped dicts).
+            image_pull_secrets: Registry pull secret names.
+            workspace_size: Default ephemeral /workspace size (e.g. "10Gi").
+            target_node: Pin the microVM to a node.
+            operating_mode: ``Running`` or ``Hibernated``.
+            manifest: Full FirecrackerSandbox object; wins over structured knobs.
+            namespace: Kubernetes namespace (maps to v1's ``workspace``).
+            api_url: API URL (default: PROKUBE_API_URL env var).
+            user_id: User ID (default: PROKUBE_USER_ID env var).
+            api_key: API key (default: PROKUBE_API_KEY env var).
+            timeout: Request timeout (default: PROKUBE_TIMEOUT env var).
+
+        Returns:
+            A SandboxV2 instance (call ``wait_until_ready()`` before use).
+        """
+        if resources:
+            vcpus = vcpus if vcpus is not None else resources.get("vcpus")
+            mem_mib = mem_mib if mem_mib is not None else resources.get("mem_mib")
+
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            info = client.create(
+                image=image,
+                name=name,
+                runtime_class=runtime_class,
+                vcpus=vcpus,
+                mem_mib=mem_mib,
+                egress=egress,
+                terminal=terminal,
+                volumes=volumes,
+                volume_mounts=volume_mounts,
+                image_pull_secrets=image_pull_secrets,
+                workspace_size=workspace_size,
+                target_node=target_node,
+                operating_mode=operating_mode,
+                manifest=manifest,
+            )
+        except Exception:
+            client.close()
+            raise
+
+        return cls(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            status=info.status,
+            image=info.image or image,
+            runtime_class=info.runtime_class or runtime_class,
+        )
+
+    @classmethod
+    def get(
+        cls,
+        name: str,
+        *,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> Self:
+        """Connect to an existing Firecracker sandbox by name."""
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            info = client.get(name)
+        except Exception:
+            client.close()
+            raise
+
+        return cls(
+            name=info.name,
+            namespace=info.namespace,
+            client=client,
+            status=info.status,
+            image=info.image,
+            runtime_class=info.runtime_class,
+        )
+
+    # Alias: SandboxV2.connect() is the same as SandboxV2.get()
+    connect = get
+
+    @classmethod
+    def list(
+        cls,
+        *,
+        phase: str | None = None,
+        namespace: str | None = None,
+        api_url: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> list[Self]:
+        """List Firecracker sandboxes in the namespace."""
+        config = cls._build_config(
+            api_url=api_url,
+            namespace=namespace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxV2Client(config)
+        try:
+            infos = client.list()
+        except Exception:
+            client.close()
+            raise
+        client.close()
+
+        if phase is not None:
+            infos = [i for i in infos if i.status.value == phase]
+        if not infos:
+            return []
+
+        sandboxes: list[Self] = []
+        try:
+            for info in infos:
+                sandboxes.append(
+                    cls(
+                        name=info.name,
+                        namespace=info.namespace,
+                        client=SandboxV2Client(config, check_version=False),
+                        status=info.status,
+                        image=info.image,
+                        runtime_class=info.runtime_class,
+                    )
+                )
+        except Exception:
+            for sbx in sandboxes:
+                sbx._client.close()
+            raise
+        return sandboxes
+
+    @classmethod
+    def from_pool(cls, *args: object, **kwargs: object) -> Self:
+        """Not supported on v2. Sandbox v2 (Firecracker) has no warm pool.
+
+        Warm-pool parity is a known future item (see the SANDBOXV2_V1_PARITY
+        doc). Use :meth:`create` + :meth:`wait_until_ready` instead.
+        """
+        raise NotImplementedError(
+            "Sandbox v2 (Firecracker) has no warm pool. `from_pool` is a future "
+            "parity item; use SandboxV2.create() + wait_until_ready() instead."
+        )
+
+    @staticmethod
+    def _build_config(
+        api_url: str | None,
+        namespace: str | None,
+        user_id: str | None,
+        api_key: str | None,
+        timeout: int | None,
+    ) -> Config:
+        """Build configuration, mapping ``namespace`` to Config.workspace."""
+        kwargs: dict = {}
+        if api_url is not None:
+            kwargs["api_url"] = api_url
+        if namespace is not None:
+            kwargs["workspace"] = namespace
+        if user_id is not None:
+            kwargs["user_id"] = user_id
+        if api_key is not None:
+            kwargs["api_key"] = api_key
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        return Config(**kwargs)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        try:
+            self.kill()
+        except Exception:
+            if exc_type is not None:
+                return False
+            raise
+        return False
+
+    def __repr__(self) -> str:
+        return (
+            f"SandboxV2(name={self._name!r}, "
+            f"namespace={self._namespace!r}, "
+            f"runtime_class={self._runtime_class!r}, "
+            f"status={self._status.value!r})"
+        )

--- a/src/prokube/sandboxv2/sandbox.py
+++ b/src/prokube/sandboxv2/sandbox.py
@@ -160,6 +160,11 @@ class SandboxV2:
     def pause(self) -> None:
         """Pause the sandbox (native VM snapshot to shared storage).
 
+        Session state (the persistent per-language child on the curated agent
+        image) survives the snapshot, so pause does NOT reset the session — a
+        subsequent :meth:`resume` restores all prior state. Callers who want a
+        clean slate call :meth:`reset_session` explicitly.
+
         Raises:
             SandboxError: If the sandbox is not in Running state (HTTP 409).
         """
@@ -170,10 +175,13 @@ class SandboxV2:
             if info.status != SandboxV2Status.UNKNOWN
             else SandboxV2Status.PAUSED
         )
-        self._code.reset_session()
 
     def resume(self) -> None:
         """Resume a paused sandbox (native VM restore).
+
+        The restored microVM keeps its pre-pause session state (variables,
+        imports, shell/node scope), so resume does NOT reset the session.
+        Callers who want a clean slate call :meth:`reset_session` explicitly.
 
         Raises:
             SandboxError: If the sandbox is not in Paused state (HTTP 409).
@@ -181,7 +189,6 @@ class SandboxV2:
         self._check_not_killed()
         info = self._client.resume(self._name)
         self._status = info.status
-        self._code.reset_session()
 
     def wait_until_ready(self, timeout: int = 120) -> None:
         """Block until the sandbox phase is Running.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
+from prokube.common.exceptions import PoolExhaustedError
 from prokube.sandbox.client import SandboxClient, _parse_status
 from prokube.sandbox.models import SandboxStatus
 
@@ -140,6 +141,32 @@ class TestListSandboxes:
         assert body["poolName"] == "python-pool"
         assert body["autoIdleTimeoutSeconds"] == 900
         assert info.auto_idle_timeout_seconds == 900
+        client.close()
+
+    def test_claim_pool_exhausted_raises_retryable_error(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """claim_from_pool exposes 429 pool_exhausted distinctly."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "10"},
+            json={"error": "pool_exhausted"},
+        )
+
+        client = SandboxClient(config)
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            client.claim_from_pool("python-pool")
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "10"
         client.close()
 
     def test_list_with_status_field(self, config, httpx_mock: HTTPXMock):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -64,3 +64,10 @@ class TestExceptions:
         """Test PoolExhaustedError inherits from SandboxError."""
         error = PoolExhaustedError("pool exhausted")
         assert isinstance(error, SandboxError)
+
+    def test_pool_exhausted_preserves_retry_metadata(self):
+        """PoolExhaustedError exposes structured retry metadata."""
+        error = PoolExhaustedError("pool exhausted", retry_after="15")
+        assert error.status_code == 429
+        assert error.reason == "pool_exhausted"
+        assert error.retry_after == "15"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
-from prokube.common.exceptions import NotFoundError, ProKubeError
+from prokube.common.exceptions import NotFoundError, PoolExhaustedError, ProKubeError
 from prokube.common.http import HttpClient
 
 
@@ -99,6 +99,42 @@ class TestHttpClient:
 
         with pytest.raises(ProKubeError, match="Internal server error"):
             http_client.get("/api/error")
+
+    def test_429_pool_exhausted_raises_pool_exhausted_error(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """Structured pool_exhausted responses are retryable typed errors."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "5"},
+            json={"reason": "pool_exhausted", "error": "pool_exhausted"},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            http_client.post("/api/sandboxes/claim", json={"poolName": "python-pool"})
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "5"
+        assert "No warm pool capacity" in str(exc_info.value)
+
+    def test_detail_429_pool_exhausted_raises_pool_exhausted_error(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """The backend may nest the structured reason under detail."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/api/sandboxes/claim",
+            status_code=429,
+            json={"detail": {"reason": "pool_exhausted"}},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            http_client.post("/api/sandboxes/claim", json={"poolName": "python-pool"})
+
+        assert exc_info.value.retry_after is None
 
     def test_auth_headers_included(
         self, http_client: HttpClient, httpx_mock: HTTPXMock

--- a/tests/test_pool_v2.py
+++ b/tests/test_pool_v2.py
@@ -197,6 +197,32 @@ class TestPoolFacade:
         finally:
             pool.close()
 
+    def test_create_template_carries_env_and_secret_refs(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json()
+        )
+        pool = SandboxV2Pool.create(
+            name="python-pool",
+            size=3,
+            image="pk-sandbox-base",
+            env_vars={"FOO": "bar"},
+            secret_refs=["openai-key"],
+        )
+        try:
+            body = json.loads(
+                [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+            )
+            # env/envFrom land in the nested pool-member template, CRD-shaped.
+            assert body["template"]["env"] == [{"name": "FOO", "value": "bar"}]
+            assert body["template"]["envFrom"] == [
+                {"secretRef": {"name": "openai-key"}}
+            ]
+        finally:
+            pool.close()
+
     def test_claim_returns_bound_sandbox(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_pool_v2.py
+++ b/tests/test_pool_v2.py
@@ -261,20 +261,43 @@ class TestPoolFacade:
 
 
 # ---------------------------------------------------------------------------
-# api-key path prefix
+# api-key ORIGIN routing
 # ---------------------------------------------------------------------------
 
 
-def test_api_key_preserves_pools_prefix(httpx_mock: HTTPXMock):
+def test_api_key_claim_uses_sandboxes_origin_route(httpx_mock: HTTPXMock):
+    """Under api-key, claim hits the sandboxes ORIGIN /claim route (pool name in
+    the body), NOT a pools sub-path — mirrors v1's ``claim_from_pool``."""
+    cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
+    httpx_mock.add_response(
+        method="POST",
+        url=f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim",
+        json=_sandbox_json(name="member-1", phase="Running"),
+    )
+    client = SandboxV2Client(cfg)
+    info = client.claim("python-pool")
+    req = httpx_mock.get_requests()[-1]
+    assert req.headers["x-api-key"] == "k"
+    assert str(req.url) == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
+    body = json.loads(req.content)
+    assert body["poolName"] == "python-pool"
+    assert info.name == "member-1"
+    client.close()
+
+
+def test_api_key_pool_crud_uses_origin_route(httpx_mock: HTTPXMock):
+    """Pool CRUD under api-key targets a top-level ORIGIN path (no /pkui, no
+    /api). Pool CRUD is not part of the deployed origin contract, but the path
+    branch must still drop the UI prefix consistently with every other method."""
     cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
     httpx_mock.add_response(
         method="GET",
-        url=f"https://prokube.ai/pkui/api/namespaces/{NS}/sandboxv2-pools",
+        url=f"https://prokube.ai/sandboxv2/{NS}/pools",
         json={"pools": [], "total": 0},
     )
     client = SandboxV2Client(cfg)
     client.list_pools()
     req = httpx_mock.get_requests()[-1]
     assert req.headers["x-api-key"] == "k"
-    assert str(req.url).endswith(f"/api/namespaces/{NS}/sandboxv2-pools")
+    assert str(req.url) == f"https://prokube.ai/sandboxv2/{NS}/pools"
     client.close()

--- a/tests/test_pool_v2.py
+++ b/tests/test_pool_v2.py
@@ -1,0 +1,254 @@
+"""Tests for the Sandbox v2 (Firecracker) warm pool (FirecrackerHibernatedPool).
+
+All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors
+test_pool.py and test_sandboxv2.py: covers create/list/get/delete pool and
+claim, asserting the ``sandboxv2-pools`` route paths, request bodies, and claim
+behavior, plus the api-key path prefix.
+"""
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from prokube.common.config import Config
+from prokube.common.exceptions import SandboxError
+from prokube.sandboxv2 import SandboxV2, SandboxV2Client, SandboxV2Pool
+
+BASE = "https://test.example.com"
+NS = "test-ns"
+POOLS = f"{BASE}/api/namespaces/{NS}/sandboxv2-pools"
+
+
+@pytest.fixture
+def config():
+    return Config(api_url=BASE, workspace=NS, user_id="test-user@example.com")
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("PROKUBE_API_URL", BASE)
+    monkeypatch.setenv("PROKUBE_WORKSPACE", NS)
+    monkeypatch.setenv("PROKUBE_USER_ID", "test-user@example.com")
+    monkeypatch.delenv("PROKUBE_API_KEY", raising=False)
+
+
+def _mock_version(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/api/version", json={"version": "0.1.0"}
+    )
+
+
+def _pool_json(name="python-pool", size=3, ready=2):
+    return {
+        "name": name,
+        "namespace": NS,
+        "size": size,
+        "readyMembers": ready,
+        "members": [
+            {"name": f"{name}-0", "phase": "Hibernated"},
+            {"name": f"{name}-1", "phase": "Hibernated"},
+        ],
+        "image": "pk-sandbox-base",
+        "runtimeClassName": "fc-host",
+    }
+
+
+def _sandbox_json(name="member-1", phase="Running", runtime="fc-host"):
+    return {
+        "name": name,
+        "namespace": NS,
+        "image": "pk-sandbox-base",
+        "runtimeClassName": runtime,
+        "phase": phase,
+        "operatingMode": "Running",
+        "terminalEnabled": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# SandboxV2Client pool methods
+# ---------------------------------------------------------------------------
+
+
+class TestClientPool:
+    def test_create_pool_path_and_body(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json()
+        )
+        from prokube.sandboxv2.models import CreateSandboxV2Request
+
+        client = SandboxV2Client(config)
+        template = CreateSandboxV2Request(
+            name="python-pool",
+            image="pk-sandbox-base",
+            runtime_class_name="fc-host",
+            vcpus=2,
+            mem_mib=2048,
+            egress=False,
+        )
+        info = client.create_pool(name="python-pool", size=3, template=template)
+
+        req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        assert str(req.url) == POOLS
+        body = json.loads(req.content)
+        assert body["name"] == "python-pool"
+        assert body["size"] == 3
+        # template is nested, camelCase-aliased, None-pruned
+        assert body["template"]["runtimeClassName"] == "fc-host"
+        assert body["template"]["vcpus"] == 2
+        assert body["template"]["memMiB"] == 2048
+        assert info.name == "python-pool"
+        assert info.size == 3
+        assert info.ready_members == 2
+        assert info.runtime_class_name == "fc-host"
+        client.close()
+
+    def test_list_pools(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=POOLS,
+            json={"pools": [_pool_json("a", 2, 1), _pool_json("b", 1, 0)], "total": 2},
+        )
+        client = SandboxV2Client(config)
+        pools = client.list_pools()
+        assert [p.name for p in pools] == ["a", "b"]
+        assert pools[0].ready_members == 1
+        client.close()
+
+    def test_get_pool(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{POOLS}/python-pool", json=_pool_json()
+        )
+        client = SandboxV2Client(config)
+        info = client.get_pool("python-pool")
+        assert info.name == "python-pool"
+        assert len(info.members) == 2
+        assert info.members[0].phase == "Hibernated"
+        client.close()
+
+    def test_delete_pool(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE", url=f"{POOLS}/python-pool", status_code=204
+        )
+        client = SandboxV2Client(config)
+        client.delete_pool("python-pool")
+        req = [r for r in httpx_mock.get_requests() if r.method == "DELETE"][-1]
+        assert str(req.url) == f"{POOLS}/python-pool"
+        client.close()
+
+    def test_claim_path_and_result(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{POOLS}/python-pool/claim",
+            json=_sandbox_json(name="member-1", phase="Running"),
+        )
+        client = SandboxV2Client(config)
+        info = client.claim("python-pool")
+        req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        assert str(req.url) == f"{POOLS}/python-pool/claim"
+        assert info.name == "member-1"
+        assert info.runtime_class == "fc-host"
+        client.close()
+
+    def test_claim_409_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{POOLS}/python-pool/claim",
+            status_code=409,
+            json={"detail": "no ready member"},
+        )
+        client = SandboxV2Client(config)
+        with pytest.raises(SandboxError):
+            client.claim("python-pool")
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# SandboxV2Pool facade
+# ---------------------------------------------------------------------------
+
+
+class TestPoolFacade:
+    def test_create_builds_fc_host_template(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json()
+        )
+        pool = SandboxV2Pool.create(
+            name="python-pool", size=3, image="pk-sandbox-base", vcpus=2, mem_mib=2048
+        )
+        try:
+            body = json.loads(
+                [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+            )
+            assert body["size"] == 3
+            assert body["template"]["runtimeClassName"] == "fc-host"
+            assert pool.name == "python-pool"
+            assert pool.size == 3
+            assert pool.ready_members == 2
+            assert pool.runtime_class == "fc-host"
+        finally:
+            pool.close()
+
+    def test_claim_returns_bound_sandbox(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{POOLS}/python-pool", json=_pool_json()
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{POOLS}/python-pool/claim",
+            json=_sandbox_json(name="member-1", phase="Running"),
+        )
+        pool = SandboxV2Pool.get("python-pool")
+        sbx = pool.claim()
+        try:
+            assert isinstance(sbx, SandboxV2)
+            assert sbx.name == "member-1"
+            # pool's own client is independent of the claimed sandbox's client
+            assert sbx._client is not pool._client
+        finally:
+            sbx._client.close()
+            pool.close()
+
+    def test_list_pools(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=POOLS,
+            json={"pools": [_pool_json("a", 2, 1)], "total": 1},
+        )
+        pools = SandboxV2Pool.list()
+        try:
+            assert len(pools) == 1
+            assert pools[0].name == "a"
+        finally:
+            for p in pools:
+                p.close()
+
+
+# ---------------------------------------------------------------------------
+# api-key path prefix
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_preserves_pools_prefix(httpx_mock: HTTPXMock):
+    cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://prokube.ai/pkui/api/namespaces/{NS}/sandboxv2-pools",
+        json={"pools": [], "total": 0},
+    )
+    client = SandboxV2Client(cfg)
+    client.list_pools()
+    req = httpx_mock.get_requests()[-1]
+    assert req.headers["x-api-key"] == "k"
+    assert str(req.url).endswith(f"/api/namespaces/{NS}/sandboxv2-pools")
+    client.close()

--- a/tests/test_pool_v2.py
+++ b/tests/test_pool_v2.py
@@ -1,4 +1,4 @@
-"""Tests for the Sandbox v2 (Firecracker) warm pool (FirecrackerHibernatedPool).
+"""Tests for the Sandbox v2 (Firecracker) warm pool (FirecrackerPool).
 
 All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors
 test_pool.py and test_sandboxv2.py: covers create/list/get/delete pool and
@@ -39,11 +39,12 @@ def _mock_version(httpx_mock: HTTPXMock) -> None:
     )
 
 
-def _pool_json(name="python-pool", size=3, ready=2):
+def _pool_json(name="python-pool", size=3, ready=2, warm_state="Hibernated"):
     return {
         "name": name,
         "namespace": NS,
         "size": size,
+        "warmState": warm_state,
         "readyMembers": ready,
         "members": [
             {"name": f"{name}-0", "phase": "Hibernated"},
@@ -95,6 +96,8 @@ class TestClientPool:
         body = json.loads(req.content)
         assert body["name"] == "python-pool"
         assert body["size"] == 3
+        # warmState defaults to Hibernated and is serialised camelCase.
+        assert body["warmState"] == "Hibernated"
         # template is nested, camelCase-aliased, None-pruned
         assert body["template"]["runtimeClassName"] == "fc-host"
         assert body["template"]["vcpus"] == 2
@@ -103,6 +106,46 @@ class TestClientPool:
         assert info.size == 3
         assert info.ready_members == 2
         assert info.runtime_class_name == "fc-host"
+        assert info.warm_state == "Hibernated"
+        client.close()
+
+    def test_create_pool_warm_state_running_in_body(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=POOLS,
+            status_code=201,
+            json=_pool_json(warm_state="Running"),
+        )
+        from prokube.sandboxv2.models import CreateSandboxV2Request
+
+        client = SandboxV2Client(config)
+        template = CreateSandboxV2Request(name="python-pool", image="pk-sandbox-base")
+        info = client.create_pool(
+            name="python-pool", size=3, template=template, warm_state="Running"
+        )
+        req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        body = json.loads(req.content)
+        assert body["warmState"] == "Running"
+        assert info.warm_state == "Running"
+        client.close()
+
+    def test_set_pool_warm_state_patches(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{POOLS}/python-pool",
+            json=_pool_json(warm_state="Running"),
+        )
+        client = SandboxV2Client(config)
+        info = client.set_pool_warm_state("python-pool", "Running")
+        req = [r for r in httpx_mock.get_requests() if r.method == "PATCH"][-1]
+        assert str(req.url) == f"{POOLS}/python-pool"
+        body = json.loads(req.content)
+        assert body == {"warmState": "Running"}
+        assert info.warm_state == "Running"
         client.close()
 
     def test_list_pools(self, config, httpx_mock: HTTPXMock):
@@ -194,6 +237,49 @@ class TestPoolFacade:
             assert pool.size == 3
             assert pool.ready_members == 2
             assert pool.runtime_class == "fc-host"
+            assert pool.warm_state == "Hibernated"
+        finally:
+            pool.close()
+
+    def test_create_warm_state_running(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=POOLS,
+            status_code=201,
+            json=_pool_json(warm_state="Running"),
+        )
+        pool = SandboxV2Pool.create(
+            name="python-pool", size=3, image="pk-sandbox-base", warm_state="Running"
+        )
+        try:
+            body = json.loads(
+                [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+            )
+            assert body["warmState"] == "Running"
+            assert pool.warm_state == "Running"
+        finally:
+            pool.close()
+
+    def test_set_warm_state_updates_pool(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{POOLS}/python-pool", json=_pool_json()
+        )
+        httpx_mock.add_response(
+            method="PATCH",
+            url=f"{POOLS}/python-pool",
+            json=_pool_json(warm_state="Running"),
+        )
+        pool = SandboxV2Pool.get("python-pool")
+        try:
+            assert pool.warm_state == "Hibernated"
+            pool.set_warm_state("Running")
+            assert pool.warm_state == "Running"
+            body = json.loads(
+                [r for r in httpx_mock.get_requests() if r.method == "PATCH"][-1].content
+            )
+            assert body == {"warmState": "Running"}
         finally:
             pool.close()
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,7 +5,7 @@ import base64
 import pytest
 from pytest_httpx import HTTPXMock
 
-from prokube.common.exceptions import SandboxError
+from prokube.common.exceptions import PoolExhaustedError, SandboxError
 from prokube.sandbox import Sandbox
 
 
@@ -175,6 +175,28 @@ class TestSandboxFromPool:
         assert body["autoIdleTimeoutSeconds"] == 900
         assert sbx.auto_idle_timeout_seconds == 900
         sbx._client.close()
+
+    def test_from_pool_exposes_pool_exhaustion(self, mock_env, httpx_mock: HTTPXMock):
+        """from_pool preserves retryable 429 pool_exhausted responses."""
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=429,
+            headers={"Retry-After": "30"},
+            json={"reason": "pool_exhausted"},
+        )
+
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            Sandbox.from_pool("python-pool")
+
+        assert exc_info.value.reason == "pool_exhausted"
+        assert exc_info.value.retry_after == "30"
+        assert "No warm pool capacity" in str(exc_info.value)
 
 
 class TestSandboxCreate:

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -126,6 +126,64 @@ class TestCreate:
         assert body["volumeMounts"] == mounts
         client.close()
 
+    def test_create_env_vars_and_secret_refs(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            env_vars={"FOO": "bar", "BAZ": "qux"},
+            secret_refs=["openai-key", "hf-token"],
+        )
+
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        # dict[str,str] -> CRD spec.env: [{name,value}]
+        assert body["env"] == [
+            {"name": "FOO", "value": "bar"},
+            {"name": "BAZ", "value": "qux"},
+        ]
+        # list[str] -> CRD spec.envFrom: [{secretRef:{name}}]
+        assert body["envFrom"] == [
+            {"secretRef": {"name": "openai-key"}},
+            {"secretRef": {"name": "hf-token"}},
+        ]
+        client.close()
+
+    def test_facade_create_env_list_form(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        SandboxV2.create(
+            image="pk-sandbox-base",
+            name="sbx",
+            env_vars=[{"name": "A", "value": "1"}],
+            secret_refs=["s1"],
+        )
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        assert body["env"] == [{"name": "A", "value": "1"}]
+        assert body["envFrom"] == [{"secretRef": {"name": "s1"}}]
+
+    def test_create_omits_env_when_absent(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx")
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        assert "env" not in body
+        assert "envFrom" not in body
+        client.close()
+
     def test_facade_create_resources_shorthand(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -15,8 +15,16 @@ from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
 from prokube.common.exceptions import SandboxError, SandboxTimeoutError
-from prokube.sandboxv2 import SandboxV2, SandboxV2Client
-from prokube.sandboxv2.models import SandboxV2Status
+from prokube.sandboxv2 import SandboxV2, SandboxV2Client, SandboxV2Pool
+from prokube.sandboxv2.models import (
+    ExecAction,
+    HTTPGetAction,
+    Lifecycle,
+    LifecycleHandler,
+    Probe,
+    SandboxV2Status,
+    TCPSocketAction,
+)
 
 BASE = "https://test.example.com"
 NS = "test-ns"
@@ -578,3 +586,231 @@ class TestApiKeyAndPool:
             )
         finally:
             sbx._client.close()
+
+
+# ---------------------------------------------------------------------------
+# Declarative startupProbe + lifecycle (RFC declarative-probes-lifecycle)
+# ---------------------------------------------------------------------------
+
+
+POOLS = f"{BASE}/api/namespaces/{NS}/sandboxv2-pools"
+
+
+def _pool_json(name="pool", size=1, warm_state="Hibernated"):
+    return {
+        "name": name,
+        "namespace": NS,
+        "size": size,
+        "warmState": warm_state,
+        "readyMembers": 0,
+        "members": [],
+        "image": "pk-sandbox-base",
+        "runtimeClassName": "fc-host",
+    }
+
+
+def _last_post_body(httpx_mock: HTTPXMock):
+    return json.loads(
+        [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+    )
+
+
+class TestProbesAndLifecycle:
+    def test_create_httpget_probe_and_poststart_serialize(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """A full pk-sandbox-base probe + POST warm-up serializes to the exact
+        CRD/back-end camelCase shape (RFC §6)."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            startup_probe=Probe(
+                http_get=HTTPGetAction(port=44772, path="/ping"),
+                period_seconds=1,
+                failure_threshold=120,
+            ),
+            lifecycle=Lifecycle(
+                post_start=LifecycleHandler(
+                    http_get=HTTPGetAction(
+                        port=44772,
+                        path="/code",
+                        method="POST",
+                        body='{"code":"1"}',
+                    )
+                )
+            ),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["startupProbe"] == {
+            "httpGet": {"port": 44772, "path": "/ping"},
+            "periodSeconds": 1,
+            "failureThreshold": 120,
+        }
+        assert body["lifecycle"] == {
+            "postStart": {
+                "httpGet": {
+                    "port": 44772,
+                    "path": "/code",
+                    "method": "POST",
+                    "body": '{"code":"1"}',
+                }
+            }
+        }
+        client.close()
+
+    def test_create_tcp_socket_probe(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            startup_probe=Probe(tcp_socket=TCPSocketAction(port=8080)),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["startupProbe"] == {"tcpSocket": {"port": 8080}}
+        client.close()
+
+    def test_create_exec_probe(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            lifecycle=Lifecycle(
+                post_start=LifecycleHandler(
+                    exec=ExecAction(command=["sh", "-c", "true"])
+                )
+            ),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["lifecycle"] == {
+            "postStart": {"exec": {"command": ["sh", "-c", "true"]}}
+        }
+        client.close()
+
+    def test_create_accepts_cr_shaped_dict(self, config, httpx_mock: HTTPXMock):
+        """A camelCase CR-shaped dict is accepted and passes through verbatim."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            startup_probe={
+                "httpGet": {
+                    "port": 9000,
+                    "path": "/healthz",
+                    "httpHeaders": [{"name": "X-Probe", "value": "1"}],
+                },
+                "initialDelaySeconds": 3,
+            },
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["startupProbe"] == {
+            "httpGet": {
+                "port": 9000,
+                "path": "/healthz",
+                "httpHeaders": [{"name": "X-Probe", "value": "1"}],
+            },
+            "initialDelaySeconds": 3,
+        }
+        client.close()
+
+    def test_probe_exactly_one_handler_enforced(self):
+        # zero handlers
+        with pytest.raises(ValueError, match="exactly one handler"):
+            Probe(period_seconds=1)
+        # two handlers
+        with pytest.raises(ValueError, match="exactly one handler"):
+            Probe(
+                http_get=HTTPGetAction(port=1),
+                tcp_socket=TCPSocketAction(port=2),
+            )
+
+    def test_lifecycle_handler_exactly_one_handler_enforced(self):
+        with pytest.raises(ValueError, match="exactly one handler"):
+            LifecycleHandler()
+        with pytest.raises(ValueError, match="exactly one handler"):
+            LifecycleHandler(
+                tcp_socket=TCPSocketAction(port=1),
+                exec=ExecAction(command=["true"]),
+            )
+
+    def test_omitted_probe_lifecycle_absent_from_json(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """Back-compat: omitting the fields drops them from the wire (exclude_none),
+        so the backend fills the execd default."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx")
+        body = _last_post_body(httpx_mock)
+        assert "startupProbe" not in body
+        assert "lifecycle" not in body
+        client.close()
+
+    def test_facade_create_threads_probe(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        sbx = SandboxV2.create(
+            name="sbx",
+            startup_probe=Probe(tcp_socket=TCPSocketAction(port=7681)),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["startupProbe"] == {"tcpSocket": {"port": 7681}}
+        sbx._client.close()
+
+    def test_pool_template_carries_probe_and_lifecycle(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Pool members declare their own probe/warm-up via the template."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json(name="p")
+        )
+        pool = SandboxV2Pool.create(
+            name="p",
+            size=2,
+            startup_probe=Probe(
+                http_get=HTTPGetAction(port=44772, path="/ping"),
+                failure_threshold=120,
+            ),
+            lifecycle=Lifecycle(
+                post_start=LifecycleHandler(
+                    http_get=HTTPGetAction(
+                        port=44772, path="/code", method="POST", body="{}"
+                    )
+                )
+            ),
+        )
+        body = _last_post_body(httpx_mock)
+        template = body["template"]
+        assert template["startupProbe"] == {
+            "httpGet": {"port": 44772, "path": "/ping"},
+            "failureThreshold": 120,
+        }
+        assert template["lifecycle"] == {
+            "postStart": {
+                "httpGet": {
+                    "port": 44772,
+                    "path": "/code",
+                    "method": "POST",
+                    "body": "{}",
+                }
+            }
+        }
+        pool._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -965,3 +965,68 @@ class TestGuestDNS:
             "options": [{"name": "ndots", "value": "3"}],
         }
         pool._client.close()
+
+
+# ---------------------------------------------------------------------------
+# Istio service mesh opt-in (spec.mesh)
+# ---------------------------------------------------------------------------
+
+
+class TestMesh:
+    def test_create_mesh_true_serializes(self, config, httpx_mock: HTTPXMock):
+        """mesh=True serializes to spec.mesh: true."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx", mesh=True)
+        body = _last_post_body(httpx_mock)
+        assert body["mesh"] is True
+        client.close()
+
+    def test_create_mesh_false_serializes(self, config, httpx_mock: HTTPXMock):
+        """mesh=False serializes to spec.mesh: false."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx", mesh=False)
+        body = _last_post_body(httpx_mock)
+        assert body["mesh"] is False
+        client.close()
+
+    def test_omitted_mesh_absent_from_json(self, config, httpx_mock: HTTPXMock):
+        """Back-compat: omitting mesh drops it from the wire (exclude_none)."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx")
+        body = _last_post_body(httpx_mock)
+        assert "mesh" not in body
+        client.close()
+
+    def test_facade_create_threads_mesh(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        sbx = SandboxV2.create(name="sbx", mesh=True)
+        body = _last_post_body(httpx_mock)
+        assert body["mesh"] is True
+        sbx._client.close()
+
+    def test_pool_template_carries_mesh(self, mock_env, httpx_mock: HTTPXMock):
+        """Pool members declare their own mesh opt-in via the template."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json(name="p")
+        )
+        pool = SandboxV2Pool.create(name="p", size=2, mesh=True)
+        body = _last_post_body(httpx_mock)
+        template = body["template"]
+        assert template["mesh"] is True
+        pool._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -8,6 +8,7 @@ claiming a warm-pool member via from_pool.
 
 import base64
 import json
+import re
 
 import pytest
 from pytest_httpx import HTTPXMock
@@ -436,12 +437,12 @@ class TestLifecycle:
         httpx_mock.add_response(
             method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
         )
-        # First refresh -> Pending, second -> Running.
+        # Prefers the server-side long-poll readiness endpoint, which returns
+        # the moment the phase reaches Running.
         httpx_mock.add_response(
-            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Pending")
-        )
-        httpx_mock.add_response(
-            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Running")
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            json=_sandbox_json(name="sbx", phase="Running"),
         )
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
         sbx.wait_until_ready(timeout=10)
@@ -453,7 +454,9 @@ class TestLifecycle:
             method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
         )
         httpx_mock.add_response(
-            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Failed")
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            json=_sandbox_json(name="sbx", phase="Failed"),
         )
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
         with pytest.raises(SandboxError):
@@ -464,12 +467,8 @@ class TestLifecycle:
         httpx_mock.add_response(
             method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
         )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{COLL}/sbx",
-            json=_sandbox_json(name="sbx", phase="Pending"),
-            is_reusable=True,
-        )
+        # timeout=0 → the deadline has already passed, so no readiness request
+        # is issued before it raises.
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
         with pytest.raises(SandboxTimeoutError):
             sbx.wait_until_ready(timeout=0)

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -965,3 +965,64 @@ class TestGuestDNS:
             "options": [{"name": "ndots", "value": "3"}],
         }
         pool._client.close()
+
+
+# Pod-mirrored snapshot resume policy (spec.snapshotResumePolicy)
+class TestSnapshotResumePolicy:
+    def test_create_snapshot_resume_policy_serializes(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """snapshotResumePolicy serializes to the exact CRD/back-end shape."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx", snapshot_resume_policy="AllowStale")
+        body = _last_post_body(httpx_mock)
+        assert body["snapshotResumePolicy"] == "AllowStale"
+        client.close()
+
+    def test_omitted_snapshot_resume_policy_absent_from_json(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """Back-compat: omitting it drops it from the wire (exclude_none), so
+        the executor applies its Strict default."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx")
+        body = _last_post_body(httpx_mock)
+        assert "snapshotResumePolicy" not in body
+        client.close()
+
+    def test_facade_create_threads_snapshot_resume_policy(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        sbx = SandboxV2.create(name="sbx", snapshot_resume_policy="AllowStale")
+        body = _last_post_body(httpx_mock)
+        assert body["snapshotResumePolicy"] == "AllowStale"
+        sbx._client.close()
+
+    def test_pool_template_carries_snapshot_resume_policy(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Pool members declare their own snapshot resume policy via the
+        template."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json(name="p")
+        )
+        pool = SandboxV2Pool.create(
+            name="p", size=2, snapshot_resume_policy="AllowStale"
+        )
+        body = _last_post_body(httpx_mock)
+        template = body["template"]
+        assert template["snapshotResumePolicy"] == "AllowStale"
+        pool._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -287,7 +287,8 @@ class TestExec:
         result = client.exec_code("sbx", "print(2+2)", language="python")
 
         body = json.loads(httpx_mock.get_requests()[-1].content)
-        assert body["use_jupyter"] is True
+        assert body["stateful"] is True
+        assert "use_jupyter" not in body
         assert body["language"] == "python"
         assert result.stdout == "4\n"
         assert result.success is True
@@ -311,7 +312,8 @@ class TestExec:
         result = client.exec_command("sbx", "echo hello")
 
         body = json.loads(httpx_mock.get_requests()[-1].content)
-        assert body["use_jupyter"] is False
+        assert body["stateful"] is False
+        assert "use_jupyter" not in body
         assert body["language"] == "bash"
         assert "session_id" not in body
         assert result.stdout == "hello\n"
@@ -1095,3 +1097,116 @@ class TestSnapshotResumePolicy:
         template = body["template"]
         assert template["snapshotResumePolicy"] == "AllowStale"
         pool._client.close()
+
+
+# ---------------------------------------------------------------------------
+# V2 session semantics (T1/T2): pause/resume preserve the session; only an
+# explicit reset_session() restarts the language child; run_code is stateful,
+# commands.run is stateless.
+# ---------------------------------------------------------------------------
+
+
+def _exec_json(session_id="sess-1"):
+    return {
+        "stdout": "",
+        "stderr": "",
+        "exitCode": 0,
+        "durationMs": 1,
+        "success": True,
+        "session_id": session_id,
+        "sandboxName": "sbx",
+    }
+
+
+class TestV2SessionSemantics:
+    def test_pause_resume_do_not_reset_session(self, config, httpx_mock: HTTPXMock):
+        """pause()+resume() must NOT arm a session reset — state survives."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(phase="Running")
+        )
+        # First run_code (establishes session), then pause, resume, run_code.
+        httpx_mock.add_response(
+            method="POST", url=f"{COLL}/sbx/exec", json=_exec_json()
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/pause",
+            json=_sandbox_json(phase="Paused"),
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/resume",
+            json=_sandbox_json(phase="Running"),
+        )
+        httpx_mock.add_response(
+            method="POST", url=f"{COLL}/sbx/exec", json=_exec_json()
+        )
+
+        sbx = SandboxV2.get("sbx", api_url=BASE, workspace=NS)
+        sbx.run_code("x = 1")
+        sbx.pause()
+        assert sbx.status == "Paused"
+        sbx.resume()
+        assert sbx.status == "Running"
+        sbx.run_code("print(x)")
+
+        exec_bodies = [
+            json.loads(r.content)
+            for r in httpx_mock.get_requests()
+            if str(r.url).endswith("/exec")
+        ]
+        assert len(exec_bodies) == 2
+        # The post-resume exec preserves the session and does NOT reset it.
+        assert exec_bodies[1]["reset_session"] is False
+        assert exec_bodies[1]["session_id"] == "sess-1"
+        assert exec_bodies[1]["stateful"] is True
+        sbx._client.close()
+
+    def test_reset_session_arms_reset_on_next_run(self, config, httpx_mock: HTTPXMock):
+        """reset_session() still restarts the child on the next run_code."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(phase="Running")
+        )
+        httpx_mock.add_response(
+            method="POST", url=f"{COLL}/sbx/exec", json=_exec_json()
+        )
+        httpx_mock.add_response(
+            method="POST", url=f"{COLL}/sbx/exec", json=_exec_json()
+        )
+
+        sbx = SandboxV2.get("sbx", api_url=BASE, workspace=NS)
+        sbx.run_code("x = 1")
+        sbx.reset_session()
+        sbx.run_code("print('fresh')")
+
+        exec_bodies = [
+            json.loads(r.content)
+            for r in httpx_mock.get_requests()
+            if str(r.url).endswith("/exec")
+        ]
+        assert exec_bodies[0]["reset_session"] is False
+        # After reset_session(), the next run_code arms context.reset and drops
+        # the stale session id.
+        assert exec_bodies[1]["reset_session"] is True
+        assert exec_bodies[1].get("session_id") is None
+        sbx._client.close()
+
+    def test_commands_run_is_stateless(self, config, httpx_mock: HTTPXMock):
+        """commands.run rides the exec endpoint with stateful=false."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(phase="Running")
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/exec",
+            json={"stdout": "hi\n", "stderr": "", "exitCode": 0, "sandboxName": "sbx"},
+        )
+        sbx = SandboxV2.get("sbx", api_url=BASE, workspace=NS)
+        sbx.commands.run("echo hi")
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["stateful"] is False
+        assert "use_jupyter" not in body
+        sbx._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -1,0 +1,443 @@
+"""Tests for the Sandbox v2 (Firecracker) client and facade.
+
+All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors the v1
+sandbox tests: covers create (fc-host AND fc-pod), run_code, commands, files,
+pause/resume, get, kill, wait_until_ready polling, the api-key path prefix, and
+the from_pool NotImplementedError guard.
+"""
+
+import base64
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from prokube.common.config import Config
+from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.sandboxv2 import SandboxV2, SandboxV2Client
+from prokube.sandboxv2.models import SandboxV2Status
+
+BASE = "https://test.example.com"
+NS = "test-ns"
+COLL = f"{BASE}/api/namespaces/{NS}/sandboxv2"
+
+
+@pytest.fixture
+def config():
+    return Config(api_url=BASE, workspace=NS, user_id="test-user@example.com")
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("PROKUBE_API_URL", BASE)
+    monkeypatch.setenv("PROKUBE_WORKSPACE", NS)
+    monkeypatch.setenv("PROKUBE_USER_ID", "test-user@example.com")
+
+
+def _mock_version(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="GET", url=f"{BASE}/api/version", json={"version": "0.1.0"}
+    )
+
+
+def _sandbox_json(name="sbx", phase="Running", runtime="fc-host"):
+    return {
+        "name": name,
+        "namespace": NS,
+        "image": "pk-sandbox-base",
+        "runtimeClassName": runtime,
+        "phase": phase,
+        "operatingMode": "Running",
+        "terminalEnabled": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    def test_create_fc_host_body_and_path(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(name="sbx-1", phase="Pending", runtime="fc-host"),
+        )
+        client = SandboxV2Client(config)
+        info = client.create(
+            image="pk-sandbox-base",
+            name="sbx-1",
+            runtime_class="fc-host",
+            vcpus=2,
+            mem_mib=2048,
+            egress=False,
+        )
+
+        req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+        body = json.loads(req.content)
+        assert str(req.url) == COLL
+        assert body["name"] == "sbx-1"
+        assert body["runtimeClassName"] == "fc-host"
+        assert body["vcpus"] == 2
+        assert body["memMiB"] == 2048
+        assert body["egress"] is False
+        assert info.name == "sbx-1"
+        assert info.status == SandboxV2Status.PENDING
+        assert info.runtime_class == "fc-host"
+        client.close()
+
+    def test_create_fc_pod(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(name="sbx-2", phase="Pending", runtime="fc-pod"),
+        )
+        client = SandboxV2Client(config)
+        info = client.create(name="sbx-2", runtime_class="fc-pod")
+
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        assert body["runtimeClassName"] == "fc-pod"
+        # image omitted -> not sent (backend default applies)
+        assert "image" not in body
+        assert info.runtime_class == "fc-pod"
+        client.close()
+
+    def test_create_passthrough_volumes(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        vols = [{"name": "ws", "ephemeral": {"storageClassName": "mayastor"}}]
+        mounts = [{"name": "ws", "mountPath": "/workspace"}]
+        client.create(name="sbx", volumes=vols, volume_mounts=mounts)
+
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        assert body["volumes"] == vols
+        assert body["volumeMounts"] == mounts
+        client.close()
+
+    def test_facade_create_resources_shorthand(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+        )
+        sbx = SandboxV2.create(
+            image="pk-sandbox-base", resources={"vcpus": 4, "mem_mib": 4096}
+        )
+        body = json.loads(
+            [r for r in httpx_mock.get_requests() if r.method == "POST"][-1].content
+        )
+        assert body["vcpus"] == 4
+        assert body["memMiB"] == 4096
+        assert sbx.runtime_class == "fc-host"
+        assert sbx.status == "Pending"
+
+
+# ---------------------------------------------------------------------------
+# Get / list / kill
+# ---------------------------------------------------------------------------
+
+
+class TestGetListKill:
+    def test_get(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx")
+        )
+        client = SandboxV2Client(config)
+        info = client.get("sbx")
+        assert info.name == "sbx"
+        assert info.status == SandboxV2Status.RUNNING
+        client.close()
+
+    def test_list(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=COLL,
+            json={
+                "sandboxes": [
+                    _sandbox_json(name="a", phase="Running"),
+                    _sandbox_json(name="b", phase="Paused"),
+                ],
+                "total": 2,
+            },
+        )
+        client = SandboxV2Client(config)
+        infos = client.list()
+        assert [i.name for i in infos] == ["a", "b"]
+        assert infos[1].status == SandboxV2Status.PAUSED
+        client.close()
+
+    def test_kill_deletes(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx")
+        )
+        httpx_mock.add_response(method="DELETE", url=f"{COLL}/sbx", status_code=204)
+        sbx = SandboxV2.get("sbx")
+        sbx.kill()
+        req = [r for r in httpx_mock.get_requests() if r.method == "DELETE"][-1]
+        assert str(req.url) == f"{COLL}/sbx"
+        with pytest.raises(SandboxError):
+            sbx.run_code("print(1)")
+
+
+# ---------------------------------------------------------------------------
+# Exec: run_code + commands
+# ---------------------------------------------------------------------------
+
+
+class TestExec:
+    def test_run_code(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/exec",
+            json={
+                "stdout": "4\n",
+                "stderr": "",
+                "exitCode": 0,
+                "durationMs": 12,
+                "success": True,
+                "session_id": "sess-1",
+                "sandboxName": "sbx",
+            },
+        )
+        client = SandboxV2Client(config)
+        result = client.exec_code("sbx", "print(2+2)", language="python")
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["use_jupyter"] is True
+        assert body["language"] == "python"
+        assert result.stdout == "4\n"
+        assert result.success is True
+        assert result.session_id == "sess-1"
+        client.close()
+
+    def test_commands_run_uses_bash_shell(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/exec",
+            json={
+                "stdout": "hello\n",
+                "stderr": "",
+                "exitCode": 0,
+                "durationMs": 5,
+                "sandboxName": "sbx",
+            },
+        )
+        client = SandboxV2Client(config)
+        result = client.exec_command("sbx", "echo hello")
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["use_jupyter"] is False
+        assert body["language"] == "bash"
+        assert "session_id" not in body
+        assert result.stdout == "hello\n"
+        assert result.exit_code == 0
+        assert result.success is True
+        client.close()
+
+    def test_command_nonzero_exit(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/exec",
+            json={"stdout": "", "stderr": "boom", "exitCode": 1, "sandboxName": "sbx"},
+        )
+        client = SandboxV2Client(config)
+        result = client.exec_command("sbx", "false")
+        assert result.exit_code == 1
+        assert result.success is False
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+
+class TestFiles:
+    def test_write_file_base64(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/files",
+            json={"message": "ok", "path": "/workspace/x.txt"},
+        )
+        client = SandboxV2Client(config)
+        client.write_file("sbx", "/workspace/x.txt", b"hello world")
+
+        body = json.loads(httpx_mock.get_requests()[-1].content)
+        assert body["path"] == "/workspace/x.txt"
+        assert body["encoding"] == "base64"
+        assert base64.b64decode(body["content"]) == b"hello world"
+        client.close()
+
+    def test_read_file(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLL}/sbx/files/download?path=%2Fworkspace%2Fx.txt",
+            content=b"data",
+        )
+        client = SandboxV2Client(config)
+        assert client.read_file("sbx", "/workspace/x.txt") == b"data"
+        client.close()
+
+    def test_list_files_maps_v2_fields(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLL}/sbx/files?path=%2Fworkspace",
+            json={
+                "files": [
+                    {
+                        "name": "a.txt",
+                        "path": "/workspace/a.txt",
+                        "size": 3,
+                        "isDirectory": False,
+                        "modifiedAt": "2026-07-05T00:00:00Z",
+                    },
+                    {
+                        "name": "sub",
+                        "path": "/workspace/sub",
+                        "size": 0,
+                        "isDirectory": True,
+                    },
+                ],
+                "path": "/workspace",
+            },
+        )
+        client = SandboxV2Client(config)
+        files = client.list_files("sbx", "/workspace")
+        assert files[0].name == "a.txt"
+        assert files[0].is_dir is False
+        assert files[0].modified == "2026-07-05T00:00:00Z"
+        assert files[1].is_dir is True
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Pause / resume / wait_until_ready
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_pause(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/pause",
+            json=_sandbox_json(name="sbx", phase="Paused"),
+        )
+        client = SandboxV2Client(config)
+        info = client.pause("sbx")
+        assert info.status == SandboxV2Status.PAUSED
+        client.close()
+
+    def test_pause_409_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/pause",
+            status_code=409,
+            json={"detail": "not running"},
+        )
+        client = SandboxV2Client(config)
+        with pytest.raises(SandboxError):
+            client.pause("sbx")
+        client.close()
+
+    def test_resume(self, config, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{COLL}/sbx/resume",
+            json=_sandbox_json(name="sbx", phase="Running"),
+        )
+        client = SandboxV2Client(config)
+        info = client.resume("sbx")
+        assert info.status == SandboxV2Status.RUNNING
+        client.close()
+
+    def test_wait_until_ready_polls(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+        )
+        # First refresh -> Pending, second -> Running.
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Pending")
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Running")
+        )
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        sbx.wait_until_ready(timeout=10)
+        assert sbx.status == "Running"
+
+    def test_wait_until_ready_failed_raises(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+        )
+        httpx_mock.add_response(
+            method="GET", url=f"{COLL}/sbx", json=_sandbox_json(name="sbx", phase="Failed")
+        )
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        with pytest.raises(SandboxError):
+            sbx.wait_until_ready(timeout=10)
+
+    def test_wait_until_ready_timeout(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{COLL}/sbx",
+            json=_sandbox_json(name="sbx", phase="Pending"),
+            is_reusable=True,
+        )
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        with pytest.raises(SandboxTimeoutError):
+            sbx.wait_until_ready(timeout=0)
+
+
+# ---------------------------------------------------------------------------
+# API-key path prefix + no warm pool
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyAndPool:
+    def test_api_key_preserves_path_prefix(self, httpx_mock: HTTPXMock):
+        cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
+        # No version check under api-key auth; the header is x-api-key.
+        httpx_mock.add_response(
+            method="GET",
+            url=f"https://prokube.ai/pkui/api/namespaces/{NS}/sandboxv2/sbx",
+            json=_sandbox_json(name="sbx"),
+        )
+        client = SandboxV2Client(cfg)
+        info = client.get("sbx")
+        req = httpx_mock.get_requests()[-1]
+        assert req.headers["x-api-key"] == "k"
+        assert info.name == "sbx"
+        client.close()
+
+    def test_from_pool_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            SandboxV2.from_pool("any-pool")

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -3,7 +3,7 @@
 All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors the v1
 sandbox tests: covers create (fc-host AND fc-pod), run_code, commands, files,
 pause/resume, get, kill, wait_until_ready polling, the api-key path prefix, and
-the from_pool NotImplementedError guard.
+claiming a warm-pool member via from_pool.
 """
 
 import base64
@@ -438,6 +438,21 @@ class TestApiKeyAndPool:
         assert info.name == "sbx"
         client.close()
 
-    def test_from_pool_not_implemented(self):
-        with pytest.raises(NotImplementedError):
-            SandboxV2.from_pool("any-pool")
+    def test_from_pool_claims_member(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/api/namespaces/{NS}/sandboxv2-pools/python-pool/claim",
+            json=_sandbox_json(name="member-1", phase="Running"),
+        )
+        sbx = SandboxV2.from_pool("python-pool")
+        try:
+            assert sbx.name == "member-1"
+            assert sbx.status == "Running"
+            assert sbx.runtime_class == "fc-host"
+            req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+            assert str(req.url).endswith(
+                f"/api/namespaces/{NS}/sandboxv2-pools/python-pool/claim"
+            )
+        finally:
+            sbx._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -1,6 +1,6 @@
 """Tests for the Sandbox v2 (Firecracker) client and facade.
 
-All HTTP is mocked (pytest_httpx) — no live cluster required. Mirrors the v1
+All HTTP is mocked (pytest_httpx or direct client stubs) — no live cluster required. Mirrors the v1
 sandbox tests: covers create (fc-host AND fc-pod), run_code, commands, files,
 pause/resume, get, kill, wait_until_ready polling, the api-key path prefix, and
 claiming a warm-pool member via from_pool.
@@ -10,11 +10,12 @@ import base64
 import json
 import re
 
+import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.config import Config
-from prokube.common.exceptions import SandboxError, SandboxTimeoutError
+from prokube.common.exceptions import NotFoundError, SandboxError, SandboxTimeoutError
 from prokube.sandboxv2 import SandboxV2, SandboxV2Client, SandboxV2Pool
 from prokube.sandboxv2.models import (
     DNSConfig,
@@ -198,7 +199,10 @@ class TestCreate:
     def test_facade_create_resources_shorthand(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         sbx = SandboxV2.create(
             image="pk-sandbox-base", resources={"vcpus": 4, "mem_mib": 4096}
@@ -444,10 +448,57 @@ class TestLifecycle:
         assert info.status == SandboxV2Status.RUNNING
         client.close()
 
+    def test_wait_ready_uses_explicit_request_timeout(self, config, monkeypatch):
+        client = SandboxV2Client(config, check_version=False)
+        calls = []
+
+        def _get(path, **kwargs):
+            calls.append((path, kwargs))
+            return _sandbox_json(name="sbx", phase="Running")
+
+        monkeypatch.setattr(client._http, "get", _get)
+
+        info = client.wait_ready("sbx", timeout=7, request_timeout=2.5)
+
+        assert info.status == SandboxV2Status.RUNNING
+        assert calls == [
+            (
+                "/api/namespaces/test-ns/sandboxv2/sbx/wait_ready",
+                {"params": {"timeout": 7}, "timeout": 2.5},
+            )
+        ]
+        client.close()
+
+    def test_wait_ready_keeps_default_request_timeout_headroom(
+        self, config, monkeypatch
+    ):
+        client = SandboxV2Client(config, check_version=False)
+        calls = []
+
+        def _get(path, **kwargs):
+            calls.append((path, kwargs))
+            return _sandbox_json(name="sbx", phase="Running")
+
+        monkeypatch.setattr(client._http, "get", _get)
+
+        info = client.wait_ready("sbx", timeout=7)
+
+        assert info.status == SandboxV2Status.RUNNING
+        assert calls == [
+            (
+                "/api/namespaces/test-ns/sandboxv2/sbx/wait_ready",
+                {"params": {"timeout": 7}, "timeout": 17},
+            )
+        ]
+        client.close()
+
     def test_wait_until_ready_polls(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         # Prefers the server-side long-poll readiness endpoint, which returns
         # the moment the phase reaches Running.
@@ -463,7 +514,10 @@ class TestLifecycle:
     def test_wait_until_ready_failed_raises(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         httpx_mock.add_response(
             method="GET",
@@ -477,13 +531,176 @@ class TestLifecycle:
     def test_wait_until_ready_timeout(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         httpx_mock.add_response(
-            method="POST", url=COLL, status_code=201, json=_sandbox_json(phase="Pending")
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
         )
         # timeout=0 → the deadline has already passed, so no readiness request
         # is issued before it raises.
         sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
         with pytest.raises(SandboxTimeoutError):
             sbx.wait_until_ready(timeout=0)
+
+    def test_wait_until_ready_pending_uses_single_timeout_budget(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        sent_timeouts: list[int] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        def _pending_callback(request):
+            timeout = int(request.url.params["timeout"])
+            sent_timeouts.append(timeout)
+            elapsed["seconds"] += timeout
+            return httpx.Response(200, json=_sandbox_json(name="sbx", phase="Pending"))
+
+        httpx_mock.add_callback(
+            _pending_callback,
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            is_reusable=True,
+        )
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
+        assert sent_timeouts == [3]
+        assert sbx.status == "Pending"
+        sbx._client.close()
+
+    def test_wait_until_ready_bounds_long_poll_http_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        server_timeouts: list[int] = []
+        request_timeouts: list[float | None] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+
+        def _timeout_wait_ready(name, timeout=30, request_timeout=None):
+            server_timeouts.append(timeout)
+            request_timeouts.append(request_timeout)
+            elapsed["seconds"] += request_timeout or 0
+            raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(sbx._client, "wait_ready", _timeout_wait_ready)
+
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
+        assert server_timeouts == [3]
+        assert request_timeouts == [3]
+        sbx._client.close()
+
+    def test_wait_until_ready_bounds_local_poll_http_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        request_timeouts: list[float | None] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+
+        def _missing_wait_ready(name, timeout=30, request_timeout=None):
+            raise NotFoundError("wait_ready not available")
+
+        def _timeout_get(name, request_timeout=None):
+            request_timeouts.append(request_timeout)
+            elapsed["seconds"] += request_timeout or 0
+            raise httpx.TimeoutException("timed out")
+
+        monkeypatch.setattr(sbx._client, "wait_ready", _missing_wait_ready)
+        monkeypatch.setattr(sbx._client, "get", _timeout_get)
+
+        with pytest.raises(
+            SandboxTimeoutError,
+            match="Sandbox sbx did not become ready within 3s .*'Pending'",
+        ):
+            sbx.wait_until_ready(timeout=3)
+
+        assert request_timeouts == [3]
+        sbx._client.close()
+
+    def test_wait_until_ready_pending_then_running_before_timeout(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=COLL,
+            status_code=201,
+            json=_sandbox_json(phase="Pending"),
+        )
+
+        elapsed = {"seconds": 0.0}
+        sent_timeouts: list[int] = []
+
+        monkeypatch.setattr("time.monotonic", lambda: elapsed["seconds"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        def _ready_callback(request):
+            timeout = int(request.url.params["timeout"])
+            sent_timeouts.append(timeout)
+            if len(sent_timeouts) == 1:
+                elapsed["seconds"] += 2
+                return httpx.Response(
+                    200, json=_sandbox_json(name="sbx", phase="Pending")
+                )
+            elapsed["seconds"] += 1
+            return httpx.Response(200, json=_sandbox_json(name="sbx", phase="Running"))
+
+        httpx_mock.add_callback(
+            _ready_callback,
+            method="GET",
+            url=re.compile(rf"{re.escape(COLL)}/sbx/wait_ready(\?.*)?$"),
+            is_reusable=True,
+        )
+
+        sbx = SandboxV2.create(image="pk-sandbox-base", name="sbx")
+        sbx.wait_until_ready(timeout=5)
+
+        assert sent_timeouts == [5, 3]
+        assert sbx.status == "Running"
+        sbx._client.close()
 
 
 # ---------------------------------------------------------------------------
@@ -552,10 +769,7 @@ class TestApiKeyAndPool:
         try:
             assert sbx.name == "member-1"
             req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
-            assert (
-                str(req.url)
-                == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
-            )
+            assert str(req.url) == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
             body = json.loads(req.content)
             assert body["poolName"] == "python-pool"
         finally:
@@ -890,9 +1104,7 @@ class TestGuestDNS:
         assert body["dnsConfig"] == {"options": [{"name": "edns0"}]}
         client.close()
 
-    def test_create_accepts_cr_shaped_dns_dict(
-        self, config, httpx_mock: HTTPXMock
-    ):
+    def test_create_accepts_cr_shaped_dns_dict(self, config, httpx_mock: HTTPXMock):
         """A camelCase CR-shaped dnsConfig dict passes through verbatim."""
         _mock_version(httpx_mock)
         httpx_mock.add_response(

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -17,6 +17,8 @@ from prokube.common.config import Config
 from prokube.common.exceptions import SandboxError, SandboxTimeoutError
 from prokube.sandboxv2 import SandboxV2, SandboxV2Client, SandboxV2Pool
 from prokube.sandboxv2.models import (
+    DNSConfig,
+    DNSConfigOption,
     ExecAction,
     HTTPGetAction,
     Lifecycle,
@@ -812,5 +814,154 @@ class TestProbesAndLifecycle:
                     "body": "{}",
                 }
             }
+        }
+        pool._client.close()
+
+
+# ---------------------------------------------------------------------------
+# Pod-mirrored guest DNS (spec.dnsPolicy + spec.dnsConfig)
+# ---------------------------------------------------------------------------
+
+
+class TestGuestDNS:
+    def test_create_dns_policy_and_config_serialize(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """dnsPolicy + a full dnsConfig serialize to the exact CRD/back-end shape,
+        with options rendered as {name, value} entries."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            dns_policy="None",
+            dns_config=DNSConfig(
+                nameservers=["1.1.1.1", "8.8.8.8"],
+                searches=["svc.cluster.local", "example.com"],
+                options=[
+                    DNSConfigOption(name="ndots", value="5"),
+                    DNSConfigOption(name="edns0"),
+                ],
+            ),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["dnsPolicy"] == "None"
+        assert body["dnsConfig"] == {
+            "nameservers": ["1.1.1.1", "8.8.8.8"],
+            "searches": ["svc.cluster.local", "example.com"],
+            "options": [
+                {"name": "ndots", "value": "5"},
+                {"name": "edns0"},
+            ],
+        }
+        client.close()
+
+    def test_create_dns_policy_only(self, config, httpx_mock: HTTPXMock):
+        """dnsPolicy alone (no dnsConfig) serializes and omits dnsConfig."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx", dns_policy="ClusterFirst")
+        body = _last_post_body(httpx_mock)
+        assert body["dnsPolicy"] == "ClusterFirst"
+        assert "dnsConfig" not in body
+        client.close()
+
+    def test_dns_config_option_value_omitted_when_absent(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """An option with no value renders as bare {name} (no null value key)."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            dns_config=DNSConfig(options=[DNSConfigOption(name="edns0")]),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["dnsConfig"] == {"options": [{"name": "edns0"}]}
+        client.close()
+
+    def test_create_accepts_cr_shaped_dns_dict(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        """A camelCase CR-shaped dnsConfig dict passes through verbatim."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(
+            name="sbx",
+            dns_policy="Default",
+            dns_config={
+                "nameservers": ["10.0.0.10"],
+                "options": [{"name": "ndots", "value": "2"}],
+            },
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["dnsPolicy"] == "Default"
+        assert body["dnsConfig"] == {
+            "nameservers": ["10.0.0.10"],
+            "options": [{"name": "ndots", "value": "2"}],
+        }
+        client.close()
+
+    def test_omitted_dns_absent_from_json(self, config, httpx_mock: HTTPXMock):
+        """Back-compat: omitting both drops them from the wire (exclude_none),
+        so the executor applies its ClusterFirst default."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        client = SandboxV2Client(config)
+        client.create(name="sbx")
+        body = _last_post_body(httpx_mock)
+        assert "dnsPolicy" not in body
+        assert "dnsConfig" not in body
+        client.close()
+
+    def test_facade_create_threads_dns(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=COLL, status_code=201, json=_sandbox_json()
+        )
+        sbx = SandboxV2.create(
+            name="sbx",
+            dns_policy="None",
+            dns_config=DNSConfig(nameservers=["9.9.9.9"]),
+        )
+        body = _last_post_body(httpx_mock)
+        assert body["dnsPolicy"] == "None"
+        assert body["dnsConfig"] == {"nameservers": ["9.9.9.9"]}
+        sbx._client.close()
+
+    def test_pool_template_carries_dns(self, mock_env, httpx_mock: HTTPXMock):
+        """Pool members declare their own DNS via the template."""
+        _mock_version(httpx_mock)
+        httpx_mock.add_response(
+            method="POST", url=POOLS, status_code=201, json=_pool_json(name="p")
+        )
+        pool = SandboxV2Pool.create(
+            name="p",
+            size=2,
+            dns_policy="ClusterFirst",
+            dns_config=DNSConfig(
+                searches=["team.svc.cluster.local"],
+                options=[DNSConfigOption(name="ndots", value="3")],
+            ),
+        )
+        body = _last_post_body(httpx_mock)
+        template = body["template"]
+        assert template["dnsPolicy"] == "ClusterFirst"
+        assert template["dnsConfig"] == {
+            "searches": ["team.svc.cluster.local"],
+            "options": [{"name": "ndots", "value": "3"}],
         }
         pool._client.close()

--- a/tests/test_sandboxv2.py
+++ b/tests/test_sandboxv2.py
@@ -476,25 +476,89 @@ class TestLifecycle:
 
 
 # ---------------------------------------------------------------------------
-# API-key path prefix + no warm pool
+# API-key ORIGIN routing + warm pool
 # ---------------------------------------------------------------------------
 
 
 class TestApiKeyAndPool:
-    def test_api_key_preserves_path_prefix(self, httpx_mock: HTTPXMock):
+    def test_api_key_uses_origin_route(self, httpx_mock: HTTPXMock):
+        """Under api-key the client targets the top-level v2 ORIGIN route.
+
+        Mirrors v1: HttpClient strips ``api_url`` to its origin, so NO ``/pkui``
+        prefix and NO ``/api`` segment — the path is ``/sandboxv2/{ws}/
+        sandboxes/{name}`` (this is the fix; the old code wrongly re-attached
+        ``/pkui/api/...`` which hit the cookie-gated UI path -> 401).
+        """
         cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
         # No version check under api-key auth; the header is x-api-key.
         httpx_mock.add_response(
             method="GET",
-            url=f"https://prokube.ai/pkui/api/namespaces/{NS}/sandboxv2/sbx",
+            url=f"https://prokube.ai/sandboxv2/{NS}/sandboxes/sbx",
             json=_sandbox_json(name="sbx"),
         )
         client = SandboxV2Client(cfg)
         info = client.get("sbx")
         req = httpx_mock.get_requests()[-1]
         assert req.headers["x-api-key"] == "k"
+        assert str(req.url) == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/sbx"
         assert info.name == "sbx"
         client.close()
+
+    def test_api_key_exec_and_files_origin_routes(self, httpx_mock: HTTPXMock):
+        """exec / files sub-paths also route to the top-level ORIGIN paths."""
+        cfg = Config(api_url="https://prokube.ai/pkui", workspace=NS, api_key="k")
+        base = f"https://prokube.ai/sandboxv2/{NS}/sandboxes/sbx"
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{base}/exec",
+            json={"stdout": "hi\n", "stderr": "", "exitCode": 0, "success": True},
+        )
+        httpx_mock.add_response(
+            method="POST", url=f"{base}/files", json={"message": "ok"}
+        )
+        client = SandboxV2Client(cfg)
+        client.exec_command("sbx", "echo hi")
+        client.write_file("sbx", "/workspace/x.txt", b"data")
+        urls = [str(r.url) for r in httpx_mock.get_requests()]
+        assert f"{base}/exec" in urls
+        assert f"{base}/files" in urls
+        client.close()
+
+    def test_api_key_claim_uses_origin_route_with_body(self, httpx_mock: HTTPXMock):
+        """Under api-key, claim POSTs to the sandboxes ORIGIN /claim route with
+        the pool name in the JSON body (mirrors v1's ``claim_from_pool``)."""
+        httpx_mock.add_response(
+            method="POST",
+            url=f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim",
+            json=_sandbox_json(name="member-1", phase="Running"),
+        )
+        sbx = SandboxV2.from_pool(
+            "python-pool",
+            api_url="https://prokube.ai/pkui",
+            workspace=NS,
+            api_key="k",
+        )
+        try:
+            assert sbx.name == "member-1"
+            req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
+            assert (
+                str(req.url)
+                == f"https://prokube.ai/sandboxv2/{NS}/sandboxes/claim"
+            )
+            body = json.loads(req.content)
+            assert body["poolName"] == "python-pool"
+        finally:
+            sbx._client.close()
+
+    def test_from_pool_signature_matches_v1(self):
+        """SandboxV2.from_pool must be drop-in for Sandbox.from_pool."""
+        import inspect
+
+        from prokube.sandbox import Sandbox
+
+        v1 = inspect.signature(Sandbox.from_pool)
+        v2 = inspect.signature(SandboxV2.from_pool)
+        assert list(v1.parameters) == list(v2.parameters)
 
     def test_from_pool_claims_member(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
@@ -508,6 +572,7 @@ class TestApiKeyAndPool:
             assert sbx.name == "member-1"
             assert sbx.status == "Running"
             assert sbx.runtime_class == "fc-host"
+            assert sbx.workspace == NS
             req = [r for r in httpx_mock.get_requests() if r.method == "POST"][-1]
             assert str(req.url).endswith(
                 f"/api/namespaces/{NS}/sandboxv2-pools/python-pool/claim"

--- a/tests/test_sandboxv2_path_contract.py
+++ b/tests/test_sandboxv2_path_contract.py
@@ -1,0 +1,86 @@
+"""Path-contract guard for the SandboxV2 backend cutover.
+
+Phase 2 of the strangler-fig migration moves the SandboxV2 backend out of the
+pkui monolith into a standalone ``fc-sandbox-api`` service. The cutover is
+**path-based ingress reroute**: the *exact same* URL paths this SDK already
+emits are re-pointed (at the ingress / Agent Gateway) to the new Service, on the
+same host. That only works if these paths stay byte-identical, so this test pins
+them. If a change here is intentional, it must be mirrored in ``fc-sandbox-api``
+(``src/fc_sandbox_api/modules/external_proxy/sandboxv2_routes.py`` and
+``modules/sandboxv2/routes.py``) *before* the contract is broken.
+
+No HTTP is performed — we assert the client's path builders directly.
+"""
+
+from __future__ import annotations
+
+from prokube.common.config import Config
+from prokube.sandboxv2 import SandboxV2Client
+
+NS = "test-ns"
+BASE = "https://test.example.com"
+
+
+def _api_key_client() -> SandboxV2Client:
+    cfg = Config(api_url=BASE, workspace=NS, api_key="secret")
+    return SandboxV2Client(cfg, check_version=False)
+
+
+def _in_cluster_client() -> SandboxV2Client:
+    cfg = Config(api_url=BASE, workspace=NS, user_id="u@example.com")
+    return SandboxV2Client(cfg, check_version=False)
+
+
+# ---------------------------------------------------------------------------
+# External (api-key) origin routes -> ingress reroute of `/sandboxv2/*`
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_paths_are_top_level_sandboxv2():
+    c = _api_key_client()
+    assert c._collection_path() == f"/sandboxv2/{NS}/sandboxes"
+    assert c._sandbox_path("sbx") == f"/sandboxv2/{NS}/sandboxes/sbx"
+    assert c._claim_path() == f"/sandboxv2/{NS}/sandboxes/claim"
+    assert (
+        c._sandbox_sub_path("sbx", "files/download")
+        == f"/sandboxv2/{NS}/sandboxes/sbx/files/download"
+    )
+    # Every api-key path must live under the single top-level `/sandboxv2/`
+    # prefix (no `/api`, no `/pkui`) so a single ingress rule reroutes them all.
+    for p in (
+        c._collection_path(),
+        c._sandbox_path("sbx"),
+        c._claim_path(),
+        c._pools_path(),
+        c._sandbox_sub_path("sbx", "exec"),
+        c._sandbox_sub_path("sbx", "wait_ready"),
+    ):
+        assert p.startswith("/sandboxv2/"), p
+
+
+# ---------------------------------------------------------------------------
+# In-cluster (Agent Gateway / header-auth) routes -> reroute of
+# `/api/namespaces/{ns}/sandboxv2*`
+# ---------------------------------------------------------------------------
+
+
+def test_in_cluster_paths_are_namespaced_under_api():
+    c = _in_cluster_client()
+    assert c._collection_path() == f"/api/namespaces/{NS}/sandboxv2"
+    assert c._sandbox_path("sbx") == f"/api/namespaces/{NS}/sandboxv2/sbx"
+    assert c._pools_path() == f"/api/namespaces/{NS}/sandboxv2-pools"
+    assert c._pool_path("p") == f"/api/namespaces/{NS}/sandboxv2-pools/p"
+    # In-cluster claim posts to the pool sub-path (pool in URL, no body).
+    assert (
+        f"{c._pool_path('p')}/claim"
+        == f"/api/namespaces/{NS}/sandboxv2-pools/p/claim"
+    )
+    # The reroute matcher keys on the `sandboxv2` token after the namespace
+    # segment; every in-cluster path must contain it under `/api/namespaces/`.
+    for p in (
+        c._collection_path(),
+        c._sandbox_path("sbx"),
+        c._pools_path(),
+        c._sandbox_sub_path("sbx", "exec"),
+    ):
+        assert p.startswith(f"/api/namespaces/{NS}/sandboxv2"), p


### PR DESCRIPTION
## Summary
- Replace stale sandbox image examples that caused ImagePullBackOff when copied into quickstarts
- Use the sandbox base image that is currently validated by pkui sandbox E2E tests and the sandbox quickstart notebook

## Testing
- git diff --check
- uv run ruff check src/prokube/sandbox/sandbox.py src/prokube/sandbox/pool.py
- PYTHONPATH=src uv run pytest tests/test_pool.py tests/test_sandbox.py -q