### PR TITLE
fix: Enforce v1 sandbox readiness timeout budget (closes #36)

### DIFF
--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -316,16 +316,25 @@ class SandboxClient:
             for s in sandboxes
         ]
 
-    def get(self, name: str) -> SandboxInfo:
+    def get(self, name: str, request_timeout: float | None = None) -> SandboxInfo:
         """Get information about a sandbox.
 
         Args:
             name: Sandbox name.
+            request_timeout: Optional per-request timeout override, in
+                seconds. Passing ``None`` (the default) leaves the client's
+                configured timeout in place; callers polling toward a
+                deadline (e.g. ``wait_until_ready``) should pass the
+                remaining budget so a single stalled request cannot outlast
+                the caller's overall timeout.
 
         Returns:
             Information about the sandbox.
         """
-        response = self._http.get(self._sandbox_path(name))
+        kwargs: dict[str, float] = {}
+        if request_timeout is not None:
+            kwargs["timeout"] = request_timeout
+        response = self._http.get(self._sandbox_path(name), **kwargs)
         return SandboxInfo(
             name=response["name"],
             workspace=self.config.workspace,

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -7,6 +7,8 @@ import sys
 import time
 import uuid
 
+import httpx
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -242,7 +244,22 @@ class Sandbox:
         poll_interval = 2
         deadline = time.monotonic() + timeout
         while True:
-            self.refresh()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                # Cap the GET at the remaining budget so a single stalled
+                # poll cannot block past the caller's deadline: without this,
+                # the request falls back to the client's default timeout
+                # (PROKUBE_TIMEOUT, 300s), which can vastly exceed a short
+                # wait_until_ready(timeout=...) call.
+                self.refresh(request_timeout=remaining)
+            except httpx.TimeoutException:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(poll_interval, remaining))
+                continue
             if self._status == SandboxStatus.RUNNING:
                 if self._skip_next_warmup:
                     self._skip_next_warmup = False
@@ -354,10 +371,15 @@ class Sandbox:
         self._killed = True
         self._client.close()
 
-    def refresh(self) -> None:
-        """Refresh sandbox information from the API."""
+    def refresh(self, request_timeout: float | None = None) -> None:
+        """Refresh sandbox information from the API.
+
+        Args:
+            request_timeout: Optional per-request timeout override, in
+                seconds. See :meth:`SandboxClient.get`.
+        """
         self._check_not_killed()
-        info = self._client.get(self._name)
+        info = self._client.get(self._name, request_timeout=request_timeout)
         self._status = info.status
         if info.auto_idle_timeout_seconds is not None:
             self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -623,10 +623,13 @@ class TestWaitUntilReady:
         tick = {"n": 0}
 
         def fake_monotonic() -> float:
-            # Advance virtual time by 1s on every call after the first few,
-            # so a timeout=2 budget is exhausted after a handful of probes.
+            # Advance virtual time by 0.1s on every call, so a timeout=2
+            # budget is exhausted after a handful of probes without being so
+            # coarse that the extra monotonic() reads wait_until_ready takes
+            # per-iteration (to bound each poll's request timeout) trip the
+            # deadline before a single probe attempt happens.
             tick["n"] += 1
-            return start + tick["n"] * 1.0
+            return start + tick["n"] * 0.1
 
         monkeypatch.setattr("time.monotonic", fake_monotonic)
         monkeypatch.setattr("time.sleep", lambda _: None)
@@ -801,6 +804,86 @@ class TestWaitUntilReady:
             method="GET",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
             json={"name": "sandbox-test", "phase": "Pending"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxTimeoutError, match="did not become ready"):
+            sbx.wait_until_ready(timeout=1)
+
+        sbx._client.close()
+
+    def test_wait_until_ready_bounds_get_to_remaining_budget(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Each readiness poll's GET must be capped at the remaining budget.
+
+        PROKUBE_TIMEOUT defaults to 300s and is used as the httpx client's
+        per-request timeout. Without an explicit per-call override, a single
+        stalled poll could block up to 300s even though the caller asked for
+        a much shorter wait_until_ready(timeout=...) budget.
+        """
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+
+        captured_timeouts: list[dict[str, float] | None] = []
+
+        def _get_callback(request: httpx.Request) -> httpx.Response:
+            captured_timeouts.append(request.extensions.get("timeout"))
+            return httpx.Response(
+                200, json={"name": "sandbox-test", "phase": "Pending"}
+            )
+
+        httpx_mock.add_callback(
+            _get_callback,
+            method="GET",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxTimeoutError):
+            sbx.wait_until_ready(timeout=3)
+
+        assert captured_timeouts, "expected at least one GET poll"
+        for sent_timeout in captured_timeouts:
+            assert sent_timeout is not None, (
+                "GET poll had no per-request timeout override, so it falls "
+                "back to the client's 300s default instead of the caller's "
+                "3s readiness budget"
+            )
+            assert sent_timeout["read"] <= 3, (
+                f"GET poll allowed a {sent_timeout['read']}s read timeout, "
+                f"but only 3s remained in the readiness budget"
+            )
+
+        sbx._client.close()
+
+    def test_wait_until_ready_get_timeout_raises_sandbox_timeout_error(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A stalled poll must surface SandboxTimeoutError, not the raw httpx
+        timeout exception, once the readiness budget is exhausted."""
+        call_count = 0
+        real_monotonic = __import__("time").monotonic
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return real_monotonic()
+            return real_monotonic() + 1000
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_exception(
+            httpx.ReadTimeout("simulated stalled backend"),
+            method="GET",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            is_reusable=True,
         )
 
         sbx = Sandbox.from_pool("python-pool")


### PR DESCRIPTION
## Summary
- Issue #36 asked for the readiness timeout to be enforced while a v1 `Sandbox` stays `Pending` (`src/prokube/sandbox/{sandbox,client,pool}.py`).
- PR #39 (`b37d6dd`) closed #36 but only touched `src/prokube/sandboxv2/*` — the wrong module. That code has since been reverted off `main` (it landed accidentally via a bad merge of `feat/sandboxv2-cutover-prep`), so #36's actual bug was never fixed.
- This PR fixes it in the right place: `SandboxClient.get()` gains an optional `request_timeout` override, `Sandbox.refresh()` forwards it, and `wait_until_ready()` passes the *remaining* readiness budget on every poll instead of relying on the client's 300s default (`PROKUBE_TIMEOUT`). A poll that times out is treated as "not ready yet" until the caller's overall deadline is exhausted, at which point `SandboxTimeoutError` is raised (previously a raw `httpx.TimeoutException` could propagate instead).

## Testing
- New tests (TDD, written to fail against the old code first):
  - `test_wait_until_ready_bounds_get_to_remaining_budget` — asserts each poll's GET is capped to the remaining budget, not the 300s default.
  - `test_wait_until_ready_get_timeout_raises_sandbox_timeout_error` — asserts a stalled poll surfaces `SandboxTimeoutError`, not the raw httpx exception.
- `uv run --extra dev python -m pytest -q` — 198 passed
- `uv run --extra dev ruff format --check` — clean
- `uv run --extra dev ruff check` — clean on all files this PR touches; repo-wide there's one pre-existing, unrelated `UP035` in `src/prokube/sandbox/commands.py` (not modified here, present on `main` before this PR)

Closes #36