### PR TITLE
feat: add paginated sandbox listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ class Sandbox:
     @classmethod
     def create(cls, image: str, **config) -> Sandbox:
         """Create sandbox directly (cold start)."""
+
+    @classmethod
+    def list_page(
+        cls,
+        lifecycle: Literal["active", "inactive"] = "active",
+        limit: int = 25,
+        continue_token: str | None = None,
+        **config,
+    ) -> SandboxPage:
+        """List one bounded page of sandboxes."""
     
     def run_code(self, code: str, language: str = "python", timeout: int = 300) -> CodeResult:
         """Execute code with stateful Jupyter kernel."""
@@ -183,6 +193,21 @@ class Sandbox:
     @property
     def files(self) -> FileManager:
         """Access file operations."""
+```
+
+Paginate large sandbox collections without loading the full workspace history:
+
+```python
+page = Sandbox.list_page(lifecycle="inactive", limit=10)
+for sandbox in page.sandboxes:
+    print(sandbox.name)
+
+if page.has_more:
+    page = Sandbox.list_page(
+        lifecycle="inactive",
+        limit=10,
+        continue_token=page.continue_token,
+    )
 ```
 
 ### CommandRunner

--- a/README.md
+++ b/README.md
@@ -173,10 +173,15 @@ class Sandbox:
     @classmethod
     def list_page(
         cls,
+        *,
         lifecycle: Literal["active", "inactive"] = "active",
         limit: int = 25,
         continue_token: str | None = None,
-        **config,
+        api_url: str | None = None,
+        workspace: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
     ) -> SandboxPage:
         """List one bounded page of sandboxes."""
     
@@ -198,22 +203,29 @@ class Sandbox:
 Paginate large sandbox collections without loading the full workspace history:
 
 - `active` (default): user sandboxes in `Running` or `Pending` phase.
-- `inactive`: user sandboxes in `Paused`, `Succeeded`, or `Failed` phase.
+- `inactive`: user sandboxes in every other phase — `Paused`, `Succeeded`,
+  `Failed`, or `Unknown`.
 
 Idle warm-pool capacity is internal infrastructure and is excluded from both
 lifecycles.
 
-```python
-page = Sandbox.list_page(lifecycle="inactive", limit=10)
-for sandbox in page.sandboxes:
-    print(sandbox.name)
+Each sandbox on a page owns its own HTTP client. Use the page as a context
+manager (or call `page.close()`) to release them without destroying the remote
+sandboxes:
 
-if page.has_more:
-    page = Sandbox.list_page(
+```python
+with Sandbox.list_page(lifecycle="inactive", limit=10) as page:
+    for sandbox in page.sandboxes:
+        print(sandbox.name)
+    next_token = page.continue_token if page.has_more else None
+
+if next_token:
+    with Sandbox.list_page(
         lifecycle="inactive",
         limit=10,
-        continue_token=page.continue_token,
-    )
+        continue_token=next_token,
+    ) as page:
+        ...
 ```
 
 ### CommandRunner

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ class Sandbox:
 
 Paginate large sandbox collections without loading the full workspace history:
 
+- `active` (default): user sandboxes in `Running` or `Pending` phase.
+- `inactive`: user sandboxes in `Paused`, `Succeeded`, or `Failed` phase.
+
+Idle warm-pool capacity is internal infrastructure and is excluded from both
+lifecycles.
+
 ```python
 page = Sandbox.list_page(lifecycle="inactive", limit=10)
 for sandbox in page.sandboxes:

--- a/src/prokube/sandbox/__init__.py
+++ b/src/prokube/sandbox/__init__.py
@@ -1,6 +1,6 @@
 """Sandbox module for prokube SDK."""
 
 from prokube.sandbox.pool import SandboxPool
-from prokube.sandbox.sandbox import Sandbox
+from prokube.sandbox.sandbox import Sandbox, SandboxPage
 
-__all__ = ["Sandbox", "SandboxPool"]
+__all__ = ["Sandbox", "SandboxPage", "SandboxPool"]

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -50,6 +50,26 @@ def _parse_status(status_str: str | None, default: SandboxStatus) -> SandboxStat
         return SandboxStatus.UNKNOWN
 
 
+def _parse_sandbox_info(raw: dict, workspace: str) -> SandboxInfo:
+    """Build a SandboxInfo from one raw sandbox list entry.
+
+    The backend has used both camelCase and snake_case spellings for these
+    fields, and reports the phase as either ``status`` or ``phase``; accept
+    every spelling so both listing endpoints stay in sync.
+    """
+    return SandboxInfo(
+        name=raw["name"],
+        workspace=workspace,
+        status=_parse_status(
+            raw.get("status") or raw.get("phase"), SandboxStatus.UNKNOWN
+        ),
+        image=raw.get("image") or None,
+        pool=raw.get("poolName") or raw.get("pool"),
+        created_at=raw.get("createdAt") or raw.get("created_at"),
+        auto_idle_timeout_seconds=parse_auto_idle_timeout(raw),
+    )
+
+
 def _parse_batch_file_write_response(
     response: dict[str, object],
 ) -> BatchFileWriteResponse:
@@ -302,20 +322,7 @@ class SandboxClient:
             self._sandboxes_path(),
         )
         sandboxes = response.get("sandboxes", [])
-        return [
-            SandboxInfo(
-                name=s["name"],
-                workspace=self.config.workspace,
-                status=_parse_status(
-                    s.get("status") or s.get("phase"), SandboxStatus.UNKNOWN
-                ),
-                image=s.get("image") or None,
-                pool=s.get("poolName") or s.get("pool"),
-                created_at=s.get("createdAt") or s.get("created_at"),
-                auto_idle_timeout_seconds=parse_auto_idle_timeout(s),
-            )
-            for s in sandboxes
-        ]
+        return [_parse_sandbox_info(s, self.config.workspace) for s in sandboxes]
 
     def list_page(
         self,
@@ -327,7 +334,9 @@ class SandboxClient:
         """List one bounded page of sandboxes.
 
         The continuation token is opaque and must be reused with the same
-        lifecycle and limit values that produced it.
+        lifecycle and limit values that produced it. An empty token means
+        "no token": the backend rejects ``continueToken=`` with HTTP 422, so
+        it is treated the same as ``None`` and requests the first page.
         """
         if not 1 <= limit <= 100:
             raise ValueError("limit must be between 1 and 100")
@@ -336,24 +345,11 @@ class SandboxClient:
             "limit": limit,
             "lifecycle": lifecycle,
         }
-        if continue_token is not None:
+        if continue_token:
             params["continueToken"] = continue_token
         response = self._http.get(self._sandboxes_path(), params=params)
         sandboxes = response.get("sandboxes", [])
-        infos = [
-            SandboxInfo(
-                name=s["name"],
-                workspace=self.config.workspace,
-                status=_parse_status(
-                    s.get("status") or s.get("phase"), SandboxStatus.UNKNOWN
-                ),
-                image=s.get("image") or None,
-                pool=s.get("poolName") or s.get("pool"),
-                created_at=s.get("createdAt") or s.get("created_at"),
-                auto_idle_timeout_seconds=parse_auto_idle_timeout(s),
-            )
-            for s in sandboxes
-        ]
+        infos = [_parse_sandbox_info(s, self.config.workspace) for s in sandboxes]
         return SandboxInfoPage(
             sandboxes=infos,
             loaded=response.get("loaded", len(infos)),

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -336,7 +336,7 @@ class SandboxClient:
             "limit": limit,
             "lifecycle": lifecycle,
         }
-        if continue_token:
+        if continue_token is not None:
             params["continueToken"] = continue_token
         response = self._http.get(self._sandboxes_path(), params=params)
         sandboxes = response.get("sandboxes", [])

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
@@ -22,6 +22,7 @@ from prokube.sandbox.models import (
     FileInfo,
     FileWriteRequest,
     SandboxInfo,
+    SandboxInfoPage,
     SandboxStatus,
     parse_auto_idle_timeout,
 )
@@ -315,6 +316,50 @@ class SandboxClient:
             )
             for s in sandboxes
         ]
+
+    def list_page(
+        self,
+        *,
+        lifecycle: Literal["active", "inactive"] = "active",
+        limit: int = 25,
+        continue_token: str | None = None,
+    ) -> SandboxInfoPage:
+        """List one bounded page of sandboxes.
+
+        The continuation token is opaque and must be reused with the same
+        lifecycle and limit values that produced it.
+        """
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+
+        params: dict[str, str | int] = {
+            "limit": limit,
+            "lifecycle": lifecycle,
+        }
+        if continue_token:
+            params["continueToken"] = continue_token
+        response = self._http.get(self._sandboxes_path(), params=params)
+        sandboxes = response.get("sandboxes", [])
+        infos = [
+            SandboxInfo(
+                name=s["name"],
+                workspace=self.config.workspace,
+                status=_parse_status(
+                    s.get("status") or s.get("phase"), SandboxStatus.UNKNOWN
+                ),
+                image=s.get("image") or None,
+                pool=s.get("poolName") or s.get("pool"),
+                created_at=s.get("createdAt") or s.get("created_at"),
+                auto_idle_timeout_seconds=parse_auto_idle_timeout(s),
+            )
+            for s in sandboxes
+        ]
+        return SandboxInfoPage(
+            sandboxes=infos,
+            loaded=response.get("loaded", len(infos)),
+            has_more=response.get("hasMore", False),
+            continue_token=response.get("continueToken"),
+        )
 
     def get(self, name: str, request_timeout: float | None = None) -> SandboxInfo:
         """Get information about a sandbox.

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -49,6 +49,15 @@ class SandboxInfo(BaseModel):
     )
 
 
+class SandboxInfoPage(BaseModel):
+    """One bounded page of sandbox information."""
+
+    sandboxes: list[SandboxInfo]
+    loaded: int
+    has_more: bool
+    continue_token: str | None = None
+
+
 class CommandResult(BaseModel):
     """Result of a shell command execution."""
 

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -6,8 +6,9 @@ import logging
 import sys
 import time
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Generic, Literal, TypeVar
 
 import httpx
 
@@ -22,19 +23,44 @@ from prokube.sandbox.client import SandboxClient
 from prokube.sandbox.code import CodeRunner
 from prokube.sandbox.commands import CommandRunner
 from prokube.sandbox.files import FileManager
-from prokube.sandbox.models import CodeResult, SandboxStatus
+from prokube.sandbox.models import CodeResult, SandboxInfo, SandboxStatus
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class SandboxPage:
-    """One bounded page of ready-to-use sandboxes."""
+SandboxT = TypeVar("SandboxT", bound="Sandbox")
 
-    sandboxes: list[Sandbox]
+
+@dataclass(frozen=True)
+class SandboxPage(Generic[SandboxT]):
+    """One bounded page of ready-to-use sandboxes.
+
+    Every sandbox on the page owns its own HTTP client. Call :meth:`close`
+    (or use the page as a context manager) to release those clients without
+    destroying the remote sandboxes; ``kill()`` is the only other path that
+    closes them, and it deletes the sandbox too.
+    """
+
+    sandboxes: list[SandboxT]
     loaded: int
     has_more: bool
     continue_token: str | None = None
+
+    def close(self) -> None:
+        """Release the HTTP client of every sandbox on this page.
+
+        Closing is idempotent and leaves the remote sandboxes untouched.
+        """
+        for sandbox in self.sandboxes:
+            sandbox._client.close()
+
+    def __enter__(self) -> Self:
+        """Enter context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit context manager - releases the page's HTTP clients."""
+        self.close()
 
 
 class Sandbox:
@@ -511,23 +537,36 @@ class Sandbox:
         if not infos:
             return []
 
-        # Each Sandbox gets its own client so that kill() on one
-        # does not invalidate the others. Skip version check since
-        # we already verified compatibility above.
+        return cls._wrap_infos(infos, config)
+
+    @classmethod
+    def _wrap_infos(cls, infos: Sequence[SandboxInfo], config: Config) -> list[Self]:
+        """Build Sandbox instances from listing results.
+
+        Each Sandbox gets its own client so that ``kill()`` on one does not
+        invalidate the others. The version check is skipped because the
+        listing client already verified compatibility. If any construction
+        fails, every client created here is closed — including the one whose
+        owning instance never came into existence.
+        """
         sandboxes: list[Self] = []
         try:
             for info in infos:
-                sandboxes.append(
-                    cls(
+                client = SandboxClient(config, check_version=False)
+                try:
+                    sandbox = cls(
                         name=info.name,
                         workspace=info.workspace,
-                        client=SandboxClient(config, check_version=False),
+                        client=client,
                         status=info.status,
                         pool=info.pool,
                         image=info.image,
                         auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
                     )
-                )
+                except Exception:
+                    client.close()
+                    raise
+                sandboxes.append(sandbox)
         except Exception:
             for sbx in sandboxes:
                 sbx._client.close()
@@ -547,7 +586,7 @@ class Sandbox:
         user_id: str | None = None,
         api_key: str | None = None,
         timeout: int | None = None,
-    ) -> SandboxPage:
+    ) -> SandboxPage[Self]:
         """List one bounded page of sandboxes.
 
         Pass ``continue_token`` from the previous page together with the same
@@ -570,27 +609,8 @@ class Sandbox:
         finally:
             client.close()
 
-        sandboxes: list[Self] = []
-        try:
-            for info in page.sandboxes:
-                sandboxes.append(
-                    cls(
-                        name=info.name,
-                        workspace=info.workspace,
-                        client=SandboxClient(config, check_version=False),
-                        status=info.status,
-                        pool=info.pool,
-                        image=info.image,
-                        auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
-                    )
-                )
-        except Exception:
-            for sandbox in sandboxes:
-                sandbox._client.close()
-            raise
-
         return SandboxPage(
-            sandboxes=sandboxes,
+            sandboxes=cls._wrap_infos(page.sandboxes, config),
             loaded=page.loaded,
             has_more=page.has_more,
             continue_token=page.continue_token,

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -6,6 +6,8 @@ import logging
 import sys
 import time
 import uuid
+from dataclasses import dataclass
+from typing import Literal
 
 import httpx
 
@@ -23,6 +25,16 @@ from prokube.sandbox.files import FileManager
 from prokube.sandbox.models import CodeResult, SandboxStatus
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SandboxPage:
+    """One bounded page of ready-to-use sandboxes."""
+
+    sandboxes: list[Sandbox]
+    loaded: int
+    has_more: bool
+    continue_token: str | None = None
 
 
 class Sandbox:
@@ -522,6 +534,67 @@ class Sandbox:
             raise
 
         return sandboxes
+
+    @classmethod
+    def list_page(
+        cls,
+        *,
+        lifecycle: Literal["active", "inactive"] = "active",
+        limit: int = 25,
+        continue_token: str | None = None,
+        api_url: str | None = None,
+        workspace: str | None = None,
+        user_id: str | None = None,
+        api_key: str | None = None,
+        timeout: int | None = None,
+    ) -> SandboxPage:
+        """List one bounded page of sandboxes.
+
+        Pass ``continue_token`` from the previous page together with the same
+        ``lifecycle`` and ``limit`` values to fetch the next page.
+        """
+        config = cls._build_config(
+            api_url=api_url,
+            workspace=workspace,
+            user_id=user_id,
+            api_key=api_key,
+            timeout=timeout,
+        )
+        client = SandboxClient(config)
+        try:
+            page = client.list_page(
+                lifecycle=lifecycle,
+                limit=limit,
+                continue_token=continue_token,
+            )
+        finally:
+            client.close()
+
+        sandboxes: list[Self] = []
+        try:
+            for info in page.sandboxes:
+                sandboxes.append(
+                    cls(
+                        name=info.name,
+                        workspace=info.workspace,
+                        client=SandboxClient(config, check_version=False),
+                        status=info.status,
+                        pool=info.pool,
+                        image=info.image,
+                        auto_idle_timeout_seconds=info.auto_idle_timeout_seconds,
+                    )
+                )
+        except Exception:
+            for sandbox in sandboxes:
+                sandbox._client.close()
+            raise
+
+        return SandboxPage(
+            sandboxes=sandboxes,
+            loaded=page.loaded,
+            has_more=page.has_more,
+            continue_token=page.continue_token,
+        )
 
     @classmethod
     def get(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,10 +128,6 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="GET",
-            url=(
-                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
-                "?limit=10&lifecycle=inactive&continueToken=opaque-token"
-            ),
             json={
                 "sandboxes": [
                     {
@@ -153,6 +149,13 @@ class TestListSandboxes:
             continue_token="opaque-token",
         )
 
+        request = httpx_mock.get_requests()[-1]
+        assert request.url.path == "/_platform/sandbox/test-ws/sandboxes"
+        assert dict(request.url.params) == {
+            "limit": "10",
+            "lifecycle": "inactive",
+            "continueToken": "opaque-token",
+        }
         assert [sandbox.name for sandbox in page.sandboxes] == ["paused-1"]
         assert page.sandboxes[0].status == SandboxStatus.PAUSED
         assert page.loaded == 1
@@ -160,7 +163,8 @@ class TestListSandboxes:
         assert page.continue_token == "next-token"
         client.close()
 
-    def test_list_page_validates_limit(self, config, httpx_mock: HTTPXMock):
+    @pytest.mark.parametrize("limit", [0, 101])
+    def test_list_page_validates_limit(self, config, httpx_mock: HTTPXMock, limit):
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
@@ -169,12 +173,14 @@ class TestListSandboxes:
 
         client = SandboxClient(config)
         with pytest.raises(ValueError, match="between 1 and 100"):
-            client.list_page(limit=101)
+            client.list_page(limit=limit)
         client.close()
 
-    def test_list_page_forwards_empty_continuation_token(
+    def test_list_page_omits_empty_continuation_token(
         self, config, httpx_mock: HTTPXMock
     ):
+        """An empty token means "first page": the backend rejects
+        ``continueToken=`` with HTTP 422, so it must not be sent."""
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
@@ -182,10 +188,6 @@ class TestListSandboxes:
         )
         httpx_mock.add_response(
             method="GET",
-            url=(
-                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
-                "?limit=25&lifecycle=active&continueToken="
-            ),
             json={"sandboxes": [], "loaded": 0, "hasMore": False},
         )
 
@@ -193,8 +195,7 @@ class TestListSandboxes:
         client.list_page(continue_token="")
 
         request = httpx_mock.get_requests()[-1]
-        assert "continueToken" in request.url.params
-        assert request.url.params["continueToken"] == ""
+        assert dict(request.url.params) == {"limit": "25", "lifecycle": "active"}
         client.close()
 
     def test_claim_sends_auto_idle_timeout(self, config, httpx_mock: HTTPXMock):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,6 +118,60 @@ class TestListSandboxes:
         assert result[1].pool is None
         client.close()
 
+    def test_list_page_preserves_pagination_metadata(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=(
+                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
+                "?limit=10&lifecycle=inactive&continueToken=opaque-token"
+            ),
+            json={
+                "sandboxes": [
+                    {
+                        "name": "paused-1",
+                        "phase": "Paused",
+                        "createdAt": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                "loaded": 1,
+                "hasMore": True,
+                "continueToken": "next-token",
+            },
+        )
+
+        client = SandboxClient(config)
+        page = client.list_page(
+            lifecycle="inactive",
+            limit=10,
+            continue_token="opaque-token",
+        )
+
+        assert [sandbox.name for sandbox in page.sandboxes] == ["paused-1"]
+        assert page.sandboxes[0].status == SandboxStatus.PAUSED
+        assert page.loaded == 1
+        assert page.has_more is True
+        assert page.continue_token == "next-token"
+        client.close()
+
+    def test_list_page_validates_limit(self, config, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+
+        client = SandboxClient(config)
+        with pytest.raises(ValueError, match="between 1 and 100"):
+            client.list_page(limit=101)
+        client.close()
+
     def test_claim_sends_auto_idle_timeout(self, config, httpx_mock: HTTPXMock):
         """claim_from_pool sends per-claim auto-idle override."""
         import json

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -172,6 +172,31 @@ class TestListSandboxes:
             client.list_page(limit=101)
         client.close()
 
+    def test_list_page_forwards_empty_continuation_token(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=(
+                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
+                "?limit=25&lifecycle=active&continueToken="
+            ),
+            json={"sandboxes": [], "loaded": 0, "hasMore": False},
+        )
+
+        client = SandboxClient(config)
+        client.list_page(continue_token="")
+
+        request = httpx_mock.get_requests()[-1]
+        assert "continueToken" in request.url.params
+        assert request.url.params["continueToken"] == ""
+        client.close()
+
     def test_claim_sends_auto_idle_timeout(self, config, httpx_mock: HTTPXMock):
         """claim_from_pool sends per-claim auto-idle override."""
         import json

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -7,6 +7,8 @@ from pytest_httpx import HTTPXMock
 
 from prokube.common.exceptions import PoolExhaustedError, SandboxError
 from prokube.sandbox import Sandbox, SandboxPage
+from prokube.sandbox.client import SandboxClient
+from prokube.sandbox.models import SandboxStatus
 
 
 @pytest.fixture
@@ -114,7 +116,7 @@ class TestSandboxList:
         sandboxes[0]._client.close()
 
     def test_list_page_returns_ready_to_use_sandboxes(
-        self, mock_env, httpx_mock: HTTPXMock
+        self, mock_env, httpx_mock: HTTPXMock, monkeypatch
     ):
         httpx_mock.add_response(
             method="GET",
@@ -123,27 +125,53 @@ class TestSandboxList:
         )
         httpx_mock.add_response(
             method="GET",
-            url=(
-                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
-                "?limit=10&lifecycle=inactive"
-            ),
             json={
-                "sandboxes": [{"name": "paused-1", "phase": "Paused"}],
-                "loaded": 1,
+                "sandboxes": [
+                    {"name": "paused-1", "phase": "Paused"},
+                    {"name": "paused-2", "phase": "Paused"},
+                ],
+                "loaded": 2,
                 "hasMore": True,
                 "continueToken": "next-token",
             },
         )
 
-        page = Sandbox.list_page(lifecycle="inactive", limit=10)
+        closed: list[SandboxClient] = []
+        real_close = SandboxClient.close
 
-        assert isinstance(page, SandboxPage)
-        assert [sandbox.name for sandbox in page.sandboxes] == ["paused-1"]
-        assert page.sandboxes[0].status == "Paused"
-        assert page.loaded == 1
-        assert page.has_more is True
-        assert page.continue_token == "next-token"
-        page.sandboxes[0]._client.close()
+        def spy_close(self: SandboxClient) -> None:
+            closed.append(self)
+            real_close(self)
+
+        monkeypatch.setattr(SandboxClient, "close", spy_close)
+
+        with Sandbox.list_page(lifecycle="inactive", limit=10) as page:
+            assert isinstance(page, SandboxPage)
+            assert [sandbox.name for sandbox in page.sandboxes] == [
+                "paused-1",
+                "paused-2",
+            ]
+            # Sandbox.status is the plain string value of the phase.
+            assert page.sandboxes[0].status == SandboxStatus.PAUSED.value
+            assert page.loaded == 2
+            assert page.has_more is True
+            assert page.continue_token == "next-token"
+            page_clients = [sandbox._client for sandbox in page.sandboxes]
+            # Every sandbox owns a distinct client, still open inside the block.
+            assert len(set(map(id, page_clients))) == 2
+            assert not any(client in closed for client in page_clients)
+
+        # Leaving the block releases the page's clients without deleting the
+        # remote sandboxes, and closing again is a no-op.
+        assert all(client in closed for client in page_clients)
+        page.close()
+        assert [request.method for request in httpx_mock.get_requests()] == [
+            "GET",
+            "GET",
+        ]
+
+        request = httpx_mock.get_requests()[-1]
+        assert dict(request.url.params) == {"limit": "10", "lifecycle": "inactive"}
 
 
 class TestSandboxFromPool:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from prokube.common.exceptions import PoolExhaustedError, SandboxError
-from prokube.sandbox import Sandbox
+from prokube.sandbox import Sandbox, SandboxPage
 
 
 @pytest.fixture
@@ -112,6 +112,38 @@ class TestSandboxList:
         assert isinstance(sandboxes[0], Sandbox)
 
         sandboxes[0]._client.close()
+
+    def test_list_page_returns_ready_to_use_sandboxes(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.1.0"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=(
+                "https://test.example.com/_platform/sandbox/test-ws/sandboxes"
+                "?limit=10&lifecycle=inactive"
+            ),
+            json={
+                "sandboxes": [{"name": "paused-1", "phase": "Paused"}],
+                "loaded": 1,
+                "hasMore": True,
+                "continueToken": "next-token",
+            },
+        )
+
+        page = Sandbox.list_page(lifecycle="inactive", limit=10)
+
+        assert isinstance(page, SandboxPage)
+        assert [sandbox.name for sandbox in page.sandboxes] == ["paused-1"]
+        assert page.sandboxes[0].status == "Paused"
+        assert page.loaded == 1
+        assert page.has_more is True
+        assert page.continue_token == "next-token"
+        page.sandboxes[0]._client.close()
 
 
 class TestSandboxFromPool:


### PR DESCRIPTION
## Summary
- add `Sandbox.list_page()` for bounded active and inactive sandbox pages
- add low-level `SandboxClient.list_page()` and pagination result models
- preserve the existing unbounded `list()` behavior for compatibility
- document opaque continuation-token usage

## Validation
- `201 passed`
- Ruff checks and formatting passed