### PR TITLE
feat!: v0.8 async sandbox lifecycle — 202s, transitional phases, lastError (SDK 0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ uv sync --dev
 ```python
 from prokube.sandbox import Sandbox
 
-# Claim a sandbox from a warm pool (instant, <100ms)
+# Claim a sandbox from a warm pool (fast, but adoption is asynchronous)
 sbx = Sandbox.from_pool("python-pool")
+sbx.wait_until_ready()
 
 # Or create directly (cold start, ~10-30s)
 sbx = Sandbox.create(image="pk-sandbox:python-datascience")
+sbx.wait_until_ready()
 
 # Execute code (stateful - variables persist between calls)
 sbx.run_code("import pandas as pd")
@@ -48,8 +50,14 @@ assert batch_result.success
 content = sbx.files.read("/workspace/output.txt")
 files = sbx.files.list("/workspace")
 
-# Cleanup
-sbx.kill()
+# Pause / resume: both are asynchronous on the backend.
+sbx.pause()               # blocks until the sandbox reports Paused
+sbx.resume()              # returns immediately, phase is Resuming
+sbx.wait_until_ready()    # block until the new pod is Running
+
+# Cleanup. Deletion (including the persistence purge that releases the name)
+# is asynchronous; pass wait=True when you need guaranteed reclamation.
+sbx.kill(wait=True)
 ```
 
 ### Context Manager
@@ -160,11 +168,12 @@ The main class for interacting with sandboxes.
 class Sandbox:
     name: str           # Sandbox name
     workspace: str      # Workspace (Kubernetes namespace)
-    status: str         # Pending, Running, Bound, Succeeded, Failed, Unknown
+    status: str         # Pending, Running, Paused, Pausing, Resuming,
+                        # Deleting, Succeeded, Failed, Unknown
     
     @classmethod
     def from_pool(cls, pool: str, **config) -> Sandbox:
-        """Claim sandbox from WarmPool (instant)."""
+        """Claim sandbox from WarmPool (fast; poll with wait_until_ready)."""
     
     @classmethod
     def create(cls, image: str, **config) -> Sandbox:
@@ -174,7 +183,6 @@ class Sandbox:
     def list_page(
         cls,
         *,
-        lifecycle: Literal["active", "inactive"] = "active",
         limit: int = 25,
         continue_token: str | None = None,
         api_url: str | None = None,
@@ -183,13 +191,22 @@ class Sandbox:
         api_key: str | None = None,
         timeout: int | None = None,
     ) -> SandboxPage:
-        """List one bounded page of sandboxes."""
+        """List one bounded page of sandboxes, across every phase."""
     
     def run_code(self, code: str, language: str = "python", timeout: int = 300) -> CodeResult:
         """Execute code with stateful Jupyter kernel."""
     
-    def kill(self) -> None:
-        """Destroy sandbox immediately."""
+    def pause(self, wait: bool = True, timeout: int = 300) -> None:
+        """Pause the sandbox; blocks until it reports Paused by default."""
+
+    def resume(self) -> None:
+        """Request a resume; returns immediately with phase Resuming."""
+
+    def wait_until_ready(self, timeout: int = 120) -> None:
+        """Block until the sandbox phase is Running."""
+
+    def kill(self, wait: bool = False, timeout: int = 300) -> None:
+        """Destroy the sandbox; deletion completes asynchronously."""
     
     @property
     def commands(self) -> CommandRunner:
@@ -200,28 +217,23 @@ class Sandbox:
         """Access file operations."""
 ```
 
-Paginate large sandbox collections without loading the full workspace history:
-
-- `active` (default): user sandboxes in `Running` or `Pending` phase.
-- `inactive`: user sandboxes in every other phase — `Paused`, `Succeeded`,
-  `Failed`, or `Unknown`.
-
-Idle warm-pool capacity is internal infrastructure and is excluded from both
-lifecycles.
+`list_page` returns one name-ordered listing across every sandbox phase. The
+continuation token is an opaque keyset cursor: pass it back together with the
+same `limit` to fetch the next page. Idle warm-pool capacity is internal
+infrastructure and never appears in the listing.
 
 Each sandbox on a page owns its own HTTP client. Use the page as a context
 manager (or call `page.close()`) to release them without destroying the remote
 sandboxes:
 
 ```python
-with Sandbox.list_page(lifecycle="inactive", limit=10) as page:
+with Sandbox.list_page(limit=10) as page:
     for sandbox in page.sandboxes:
         print(sandbox.name)
     next_token = page.continue_token if page.has_more else None
 
 if next_token:
     with Sandbox.list_page(
-        lifecycle="inactive",
         limit=10,
         continue_token=next_token,
     ) as page:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ sbx.kill(wait=True)
 from prokube.sandbox import Sandbox
 
 with Sandbox.from_pool("python-pool") as sbx:
+    sbx.wait_until_ready()
     result = sbx.run_code("print(42)")
     print(result.stdout)
 # Sandbox is automatically cleaned up
@@ -101,6 +102,7 @@ export PROKUBE_WORKSPACE=henrik
 from prokube.sandbox import Sandbox
 
 with Sandbox.from_pool("python-pool") as sbx:
+    sbx.wait_until_ready()
     result = sbx.run_code("print('Hello from inside the workspace!')")
     print(result.stdout)
 ```
@@ -136,6 +138,7 @@ from prokube.sandbox import Sandbox
 
 # API key is picked up from PROKUBE_API_KEY env var
 with Sandbox.from_pool("python-pool") as sbx:
+    sbx.wait_until_ready()
     result = sbx.run_code("print('Hello from outside the cluster!')")
     print(result.stdout)
 ```
@@ -151,6 +154,7 @@ with Sandbox.from_pool(
     workspace="my-workspace",
     api_key="your-api-key",
 ) as sbx:
+    sbx.wait_until_ready()
     result = sbx.run_code("print('Hello from outside the cluster!')")
     print(result.stdout)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prokube-sdk"
-version = "0.1.3"
+version = "0.2.0"
 description = "Python SDK for prokube.ai platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prokube/_version.py
+++ b/src/prokube/_version.py
@@ -1,3 +1,3 @@
 """Version information for prokube-sdk."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/prokube/common/compat.py
+++ b/src/prokube/common/compat.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from prokube.common.http import HttpClient
 
 # Minimum required backend version for this SDK version
-MIN_BACKEND_VERSION = "0.1.0"
+MIN_BACKEND_VERSION = "0.8.0"
 
 
 def parse_version(version_string: str) -> tuple[int, int, int]:

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from prokube.common.compat import check_backend_compatibility
 from prokube.common.exceptions import NotFoundError, ProKubeError, SandboxError
@@ -50,23 +50,26 @@ def _parse_status(status_str: str | None, default: SandboxStatus) -> SandboxStat
         return SandboxStatus.UNKNOWN
 
 
-def _parse_sandbox_info(raw: dict, workspace: str) -> SandboxInfo:
-    """Build a SandboxInfo from one raw sandbox list entry.
+def _parse_sandbox_info(
+    raw: dict,
+    workspace: str,
+    default_status: SandboxStatus = SandboxStatus.UNKNOWN,
+) -> SandboxInfo:
+    """Build a SandboxInfo from one raw backend Sandbox body.
 
     The backend has used both camelCase and snake_case spellings for these
     fields, and reports the phase as either ``status`` or ``phase``; accept
-    every spelling so both listing endpoints stay in sync.
+    every spelling so all endpoints stay in sync.
     """
     return SandboxInfo(
         name=raw["name"],
         workspace=workspace,
-        status=_parse_status(
-            raw.get("status") or raw.get("phase"), SandboxStatus.UNKNOWN
-        ),
+        status=_parse_status(raw.get("status") or raw.get("phase"), default_status),
         image=raw.get("image") or None,
         pool=raw.get("poolName") or raw.get("pool"),
         created_at=raw.get("createdAt") or raw.get("created_at"),
         auto_idle_timeout_seconds=parse_auto_idle_timeout(raw),
+        last_error=raw.get("lastError") or raw.get("last_error"),
     )
 
 
@@ -218,6 +221,10 @@ class SandboxClient:
     ) -> SandboxInfo:
         """Claim a sandbox from a warm pool.
 
+        The backend accepts the claim with HTTP 202 and adopts a warm pod
+        asynchronously, so the returned sandbox usually starts out Pending.
+        Poll :meth:`get` (or ``Sandbox.wait_until_ready``) until it is Running.
+
         Args:
             pool: Name of the warm pool.
             auto_idle_timeout_seconds: Per-claim auto-idle override in seconds.
@@ -233,20 +240,14 @@ class SandboxClient:
             f"{self._sandboxes_path()}/claim",
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
-        # API returns sandboxName for claim endpoint
-        sandbox_name = response.get("sandboxName") or response["name"]
-        response_auto_idle_timeout = parse_auto_idle_timeout(response)
-        return SandboxInfo(
-            name=sandbox_name,
-            workspace=self.config.workspace,
-            status=_parse_status(response.get("status"), SandboxStatus.RUNNING),
-            pool=pool,
-            auto_idle_timeout_seconds=(
-                response_auto_idle_timeout
-                if response_auto_idle_timeout is not None
-                else auto_idle_timeout_seconds
-            ),
+        info = _parse_sandbox_info(
+            response, self.config.workspace, SandboxStatus.PENDING
         )
+        if info.pool is None:
+            info.pool = pool
+        if info.auto_idle_timeout_seconds is None:
+            info.auto_idle_timeout_seconds = auto_idle_timeout_seconds
+        return info
 
     def create(
         self,
@@ -297,20 +298,13 @@ class SandboxClient:
             self._sandboxes_path(),
             json=request.model_dump(by_alias=True, exclude_none=True),
         )
-        # API returns 'phase' instead of 'status' for sandbox phase
-        status_str = response.get("status") or response.get("phase")
-        response_auto_idle_timeout = parse_auto_idle_timeout(response)
-        return SandboxInfo(
-            name=response["name"],
-            workspace=self.config.workspace,
-            status=_parse_status(status_str, SandboxStatus.PENDING),
-            image=image,
-            auto_idle_timeout_seconds=(
-                response_auto_idle_timeout
-                if response_auto_idle_timeout is not None
-                else auto_idle_timeout_seconds
-            ),
+        info = _parse_sandbox_info(
+            response, self.config.workspace, SandboxStatus.PENDING
         )
+        info.image = info.image or image
+        if info.auto_idle_timeout_seconds is None:
+            info.auto_idle_timeout_seconds = auto_idle_timeout_seconds
+        return info
 
     def list(self) -> list[SandboxInfo]:
         """List all sandboxes in the configured workspace.
@@ -327,24 +321,21 @@ class SandboxClient:
     def list_page(
         self,
         *,
-        lifecycle: Literal["active", "inactive"] = "active",
         limit: int = 25,
         continue_token: str | None = None,
     ) -> SandboxInfoPage:
         """List one bounded page of sandboxes.
 
-        The continuation token is opaque and must be reused with the same
-        lifecycle and limit values that produced it. An empty token means
-        "no token": the backend rejects ``continueToken=`` with HTTP 422, so
-        it is treated the same as ``None`` and requests the first page.
+        There is exactly one name-ordered listing across every sandbox state.
+        The continuation token is an opaque keyset cursor and must be reused
+        with the same limit that produced it. An empty token means "no token":
+        the backend rejects ``continueToken=`` with HTTP 422, so it is treated
+        the same as ``None`` and requests the first page.
         """
         if not 1 <= limit <= 100:
             raise ValueError("limit must be between 1 and 100")
 
-        params: dict[str, str | int] = {
-            "limit": limit,
-            "lifecycle": lifecycle,
-        }
+        params: dict[str, str | int] = {"limit": limit}
         if continue_token:
             params["continueToken"] = continue_token
         response = self._http.get(self._sandboxes_path(), params=params)
@@ -359,6 +350,8 @@ class SandboxClient:
 
     def get(self, name: str, request_timeout: float | None = None) -> SandboxInfo:
         """Get information about a sandbox.
+
+        This is the poll target for every asynchronous lifecycle operation.
 
         Args:
             name: Sandbox name.
@@ -376,47 +369,47 @@ class SandboxClient:
         if request_timeout is not None:
             kwargs["timeout"] = request_timeout
         response = self._http.get(self._sandbox_path(name), **kwargs)
-        return SandboxInfo(
-            name=response["name"],
-            workspace=self.config.workspace,
-            status=_parse_status(
-                response.get("status") or response.get("phase"),
-                SandboxStatus.UNKNOWN,
-            ),
-            image=response.get("image"),
-            pool=response.get("poolName") or response.get("pool"),
-            created_at=response.get("createdAt") or response.get("created_at"),
-            auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
-        )
+        return _parse_sandbox_info(response, self.config.workspace)
 
-    def pause(self, name: str) -> None:
+    def pause(self, name: str) -> SandboxInfo:
         """Pause a running sandbox.
 
         Frees compute resources while preserving /workspace and /home/agent.
-
-        Args:
-            name: Sandbox name.
-
-        Raises:
-            SandboxError: If sandbox is not in Running state (HTTP 409).
-        """
-        try:
-            self._http.post(self._sandbox_sub_path(name, "pause"))
-        except ProKubeError as e:
-            if e.status_code == 409:
-                raise SandboxError(str(e), status_code=409) from e
-            raise
-
-    def resume(self, name: str) -> SandboxInfo:
-        """Resume a paused sandbox.
-
-        A new pod starts with the same PVC mounts at /workspace and /home/agent.
+        The backend accepts the request with HTTP 202 and reports phase
+        ``Pausing`` until its worker settles the sandbox on ``Paused``; poll
+        :meth:`get` to observe the final phase.
 
         Args:
             name: Sandbox name.
 
         Returns:
-            Updated sandbox information after the resume request.
+            Sandbox information as of the accepted pause request.
+
+        Raises:
+            SandboxError: If sandbox is not in Running state (HTTP 409).
+        """
+        try:
+            response = self._http.post(self._sandbox_sub_path(name, "pause"))
+        except ProKubeError as e:
+            if e.status_code == 409:
+                raise SandboxError(str(e), status_code=409) from e
+            raise
+        return _parse_sandbox_info(
+            response, self.config.workspace, SandboxStatus.PAUSING
+        )
+
+    def resume(self, name: str) -> SandboxInfo:
+        """Resume a paused sandbox.
+
+        A new pod starts with the same PVC mounts at /workspace and /home/agent.
+        The backend accepts the request with HTTP 202 and reports phase
+        ``Resuming`` until the new pod is up; poll :meth:`get` until Running.
+
+        Args:
+            name: Sandbox name.
+
+        Returns:
+            Sandbox information as of the accepted resume request.
 
         Raises:
             SandboxError: If sandbox is not in Paused state (HTTP 409).
@@ -427,28 +420,17 @@ class SandboxClient:
             if e.status_code == 409:
                 raise SandboxError(str(e), status_code=409) from e
             raise
-
-        status_str = response.get("phase") or response.get("status")
-        if isinstance(status_str, str) and status_str.lower() == "ok":
-            status_str = None
-
-        resumed_from_pool = response.get("resumedFromPool")
-        if resumed_from_pool is None:
-            resumed_from_pool = response.get("resumed_from_pool") or False
-
-        return SandboxInfo(
-            name=response.get("name", name),
-            workspace=self.config.workspace,
-            status=_parse_status(status_str, SandboxStatus.PENDING),
-            image=response.get("image"),
-            pool=response.get("poolName") or response.get("pool"),
-            created_at=response.get("createdAt") or response.get("created_at"),
-            auto_idle_timeout_seconds=parse_auto_idle_timeout(response),
-            resumed_from_pool=resumed_from_pool,
+        return _parse_sandbox_info(
+            response, self.config.workspace, SandboxStatus.RESUMING
         )
 
     def delete(self, name: str) -> None:
         """Delete a sandbox.
+
+        The backend accepts the request with HTTP 202 and an empty body, then
+        tears the sandbox down (including its persistence records)
+        asynchronously. Poll :meth:`get` until it raises
+        :class:`NotFoundError` to know the name has been released.
 
         Args:
             name: Sandbox name.

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -294,10 +294,18 @@ class SandboxClient:
             env_vars=env_vars,
             secret_refs=secret_refs,
         )
-        response = self._http.post(
-            self._sandboxes_path(),
-            json=request.model_dump(by_alias=True, exclude_none=True),
-        )
+        # The backend has two create wire shapes: the internal route's
+        # CreateSandboxRequest nests cpu/memory under `resources` (and
+        # silently ignores top-level keys), while the external API-key
+        # route's ExternalCreateRequest takes them flat (and ignores
+        # `resources`). Send both; each route reads its own shape.
+        payload = request.model_dump(by_alias=True, exclude_none=True)
+        resources = {
+            key: value for key, value in {"cpu": cpu, "memory": memory}.items() if value
+        }
+        if resources:
+            payload["resources"] = resources
+        response = self._http.post(self._sandboxes_path(), json=payload)
         info = _parse_sandbox_info(
             response, self.config.workspace, SandboxStatus.PENDING
         )

--- a/src/prokube/sandbox/commands.py
+++ b/src/prokube/sandbox/commands.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from prokube.sandbox.models import CommandResult
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -22,7 +22,9 @@ class SandboxStatus(str, Enum):
     PENDING = "Pending"
     RUNNING = "Running"
     PAUSED = "Paused"
-    BOUND = "Bound"  # Claim is bound to a sandbox (ready to use)
+    PAUSING = "Pausing"
+    RESUMING = "Resuming"
+    DELETING = "Deleting"
     SUCCEEDED = "Succeeded"
     FAILED = "Failed"
     UNKNOWN = "Unknown"
@@ -43,9 +45,9 @@ class SandboxInfo(BaseModel):
         default=None,
         description="Auto-idle timeout override in seconds, when configured",
     )
-    resumed_from_pool: bool = Field(
-        default=False,
-        description="True when a resume response came from a warm-pool swap",
+    last_error: str | None = Field(
+        default=None,
+        description="Why the last lifecycle step failed, when the phase is Failed",
     )
 
 

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -135,6 +135,7 @@ class Sandbox:
         self._image = image
         self._auto_idle_timeout_seconds = auto_idle_timeout_seconds
         self._killed = False
+        self._delete_requested = False
         self._last_error: str | None = None
 
         # Initialize helpers with killed-state check callback
@@ -143,10 +144,15 @@ class Sandbox:
         self._code = CodeRunner(client, name, self._check_not_killed)
 
     def _check_not_killed(self) -> None:
-        """Raise error if sandbox has been killed."""
+        """Raise error if the sandbox has been killed or is being deleted."""
         if self._killed:
             raise SandboxError(
                 f"Sandbox {self._name} has been killed and cannot be used anymore"
+            )
+        if self._delete_requested:
+            raise SandboxError(
+                f"Sandbox {self._name} is being deleted; call kill(wait=True) "
+                "to wait for the deletion to complete"
             )
 
     @property
@@ -282,6 +288,11 @@ class Sandbox:
                 self.refresh(request_timeout=remaining)
             except httpx.TimeoutException:
                 pass
+            except NotFoundError:
+                # A concurrently admitted delete finished while we waited.
+                raise SandboxError(
+                    f"Sandbox {self._name} was deleted while waiting for it to pause"
+                ) from None
             else:
                 if self._status == SandboxStatus.PAUSED:
                     return
@@ -290,6 +301,14 @@ class Sandbox:
                         f"Sandbox {self._name} failed to pause: "
                         f"{self._last_error or 'no error reported by the backend'} "
                         f"(re-issue pause() to retry)"
+                    )
+                if self._status == SandboxStatus.DELETING:
+                    # Delete outranks pause on the backend: the pause worker's
+                    # settle will miss and the sandbox is going away. Waiting
+                    # any longer can only end in 404.
+                    raise SandboxError(
+                        f"Sandbox {self._name} is being deleted; it will "
+                        "never reach Paused"
                     )
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -463,23 +482,41 @@ class Sandbox:
         ``wait=True`` when you intend to reuse the name (or need the quota
         back) and must know the reclamation finished.
 
-        After calling this method, the sandbox cannot be used anymore.
-        Any subsequent calls to run_code(), commands, or files will raise.
+        After a successful ``kill()`` (or once the delete has been admitted),
+        the sandbox cannot be used anymore: run_code(), commands, and files
+        raise. If waiting fails or times out, the object stays in a
+        deletion-requested state — normal operations are blocked, but
+        ``kill(wait=True)`` may be re-issued to keep waiting (the backend's
+        DELETE is idempotent while teardown is in flight).
 
-        If the delete request fails, an exception is raised and the sandbox
-        remains usable so callers can retry or handle the failure.
+        If the initial delete request itself fails, an exception is raised
+        and the sandbox remains usable so callers can retry.
 
         Args:
             wait: Poll until the sandbox is really gone (default: False).
             timeout: Maximum seconds to wait when ``wait`` is True.
 
         Raises:
+            SandboxError: If ``wait`` is True and the backend lands the
+                delete in a terminal failure (phase ``Failed`` with
+                ``lastError``); re-issue ``kill()`` to retry the delete.
             SandboxTimeoutError: If ``wait`` is True and the sandbox is still
                 present after ``timeout`` seconds.
         """
         if self._killed:
             return  # Already killed, nothing to do
-        self._client.delete(self._name)
+        try:
+            self._client.delete(self._name)
+        except NotFoundError:
+            # A re-issued kill can find the sandbox already gone: that is
+            # the outcome we wanted, not an error.
+            self._status = SandboxStatus.SUCCEEDED
+            self._killed = True
+            self._client.close()
+            return
+        # The delete is admitted: from here the sandbox is going away and
+        # must not accept work, even if the wait below fails or times out.
+        self._delete_requested = True
         if wait:
             self._wait_until_gone(timeout)
         # Only mark as killed and close client after successful delete
@@ -503,6 +540,16 @@ class Sandbox:
                 pass
             else:
                 self._status = info.status
+                self._last_error = info.last_error
+                if self._status == SandboxStatus.FAILED:
+                    # delete_failed on the backend: retries are exhausted and
+                    # the row (and name) stay reserved until a delete is
+                    # re-issued and succeeds.
+                    raise SandboxError(
+                        f"Sandbox {self._name} failed to delete: "
+                        f"{self._last_error or 'no error reported by the backend'} "
+                        f"(re-issue kill() to retry)"
+                    )
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeVar
+from typing import Generic, TypeVar
 
 import httpx
 
@@ -18,7 +18,12 @@ else:
     from typing_extensions import Self
 
 from prokube.common.config import Config
-from prokube.common.exceptions import ProKubeError, SandboxError, SandboxTimeoutError
+from prokube.common.exceptions import (
+    NotFoundError,
+    ProKubeError,
+    SandboxError,
+    SandboxTimeoutError,
+)
 from prokube.sandbox.client import SandboxClient
 from prokube.sandbox.code import CodeRunner
 from prokube.sandbox.commands import CommandRunner
@@ -70,8 +75,9 @@ class Sandbox:
     They can be created directly or claimed from a warm pool for faster startup.
 
     Example:
-        >>> # Claim from warm pool (instant, <100ms)
+        >>> # Claim from warm pool (fast, but adoption is asynchronous)
         >>> sbx = Sandbox.from_pool("python-pool")
+        >>> sbx.wait_until_ready()
         >>>
         >>> # Execute code (stateful)
         >>> sbx.run_code("import pandas as pd")
@@ -86,11 +92,12 @@ class Sandbox:
         >>> sbx.files.write("/workspace/test.txt", "hello world")
         >>> content = sbx.files.read("/workspace/test.txt")
         >>>
-        >>> # Cleanup
-        >>> sbx.kill()
+        >>> # Cleanup (deletion completes asynchronously)
+        >>> sbx.kill(wait=True)
 
     Context Manager:
         >>> with Sandbox.from_pool("python-pool") as sbx:
+        ...     sbx.wait_until_ready()
         ...     result = sbx.run_code("print(42)")
         ...     print(result.stdout)
         # Sandbox is automatically killed
@@ -128,7 +135,7 @@ class Sandbox:
         self._image = image
         self._auto_idle_timeout_seconds = auto_idle_timeout_seconds
         self._killed = False
-        self._skip_next_warmup = False
+        self._last_error: str | None = None
 
         # Initialize helpers with killed-state check callback
         self._commands = CommandRunner(client, name, self._check_not_killed)
@@ -232,21 +239,66 @@ class Sandbox:
         """Get the configured auto-idle timeout override in seconds, if known."""
         return self._auto_idle_timeout_seconds
 
-    def pause(self) -> None:
+    def pause(self, wait: bool = True, timeout: int = 300) -> None:
         """Pause the sandbox. Frees compute resources.
 
         Preserves: /workspace (working directory) and /home/agent (HOME, pip --user, dotfiles).
         Lost: running processes, apt-installed system packages, /tmp.
 
+        The backend accepts the pause asynchronously (phase ``Pausing``). By
+        default this method blocks until the sandbox reports ``Paused``.
+
+        Args:
+            wait: Block until the sandbox has actually reached Paused
+                (default: True). Pass False to return as soon as the backend
+                accepted the request, leaving the phase at ``Pausing``.
+            timeout: Maximum seconds to wait when ``wait`` is True.
+
         Raises:
-            SandboxError: If sandbox is not in Running state.
+            SandboxError: If sandbox is not in Running state, or if the pause
+                fails (phase ``Failed``). Re-issuing ``pause()`` retries.
+            SandboxTimeoutError: If the sandbox does not reach Paused within
+                ``timeout`` seconds.
         """
         self._check_not_killed()
-        self._client.pause(self._name)
-        self._status = SandboxStatus.PAUSED
+        info = self._client.pause(self._name)
+        self._status = info.status
+        self._last_error = info.last_error
         # Pausing deletes the underlying pod, so any existing Jupyter session
         # is no longer valid. Reset so next run_code() starts a fresh kernel.
         self._code.reset_session()
+        if wait:
+            self._wait_for_pause(timeout)
+
+    def _wait_for_pause(self, timeout: int) -> None:
+        """Poll until the sandbox settles on Paused, Failed, or the deadline."""
+        poll_interval = 2
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                self.refresh(request_timeout=remaining)
+            except httpx.TimeoutException:
+                pass
+            else:
+                if self._status == SandboxStatus.PAUSED:
+                    return
+                if self._status == SandboxStatus.FAILED:
+                    raise SandboxError(
+                        f"Sandbox {self._name} failed to pause: "
+                        f"{self._last_error or 'no error reported by the backend'} "
+                        f"(re-issue pause() to retry)"
+                    )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(poll_interval, remaining))
+        raise SandboxTimeoutError(
+            f"Sandbox {self._name} did not pause within {timeout}s "
+            f"(current phase: {self._status.value!r})"
+        )
 
     def resume(self) -> None:
         """Resume a paused sandbox.
@@ -255,28 +307,35 @@ class Sandbox:
         If /home/agent/.sandbox-restore.sh exists, it runs automatically on
         startup to reinstall system packages.
 
+        The backend accepts the resume asynchronously and reports phase
+        ``Resuming``; this call does not block. Use
+        :meth:`wait_until_ready` to wait for the new pod to become Running.
+
         Raises:
             SandboxError: If sandbox is not in Paused state.
         """
         self._check_not_killed()
         info = self._client.resume(self._name)
         self._status = info.status
+        self._last_error = info.last_error
         if info.auto_idle_timeout_seconds is not None:
             self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
-        self._skip_next_warmup = info.resumed_from_pool
         # New pod means previous Jupyter session is invalid.
         self._code.reset_session()
 
     def wait_until_ready(self, timeout: int = 120) -> None:
         """Block until sandbox phase is Running. Useful after resume().
 
+        Transitional phases (Pending, Pausing, Resuming) simply keep polling.
+
         Args:
             timeout: Maximum seconds to wait (default: 120).
 
         Raises:
             SandboxTimeoutError: If sandbox does not become Running within timeout.
-            SandboxError: If the sandbox enters a terminal state (Failed/Succeeded)
-                while waiting for it to become ready.
+            SandboxError: If the sandbox enters a state from which it can no
+                longer become ready (Failed, Succeeded, or Deleting). For a
+                failed sandbox the backend's ``lastError`` is included.
         """
         self._check_not_killed()
         poll_interval = 2
@@ -299,15 +358,18 @@ class Sandbox:
                 time.sleep(min(poll_interval, remaining))
                 continue
             if self._status == SandboxStatus.RUNNING:
-                if self._skip_next_warmup:
-                    self._skip_next_warmup = False
-                    return
                 self._warmup_kernel(deadline)
                 return
-            if self._status in (SandboxStatus.FAILED, SandboxStatus.SUCCEEDED):
+            if self._status in (
+                SandboxStatus.FAILED,
+                SandboxStatus.SUCCEEDED,
+                SandboxStatus.DELETING,
+            ):
+                detail = f": {self._last_error}" if self._last_error else ""
                 raise SandboxError(
                     f"Sandbox {self._name} entered terminal state "
-                    f"{self._status.value!r} while waiting for it to become ready"
+                    f"{self._status.value!r} while waiting for it to become "
+                    f"ready{detail}"
                 )
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -392,22 +454,63 @@ class Sandbox:
             sleep_for = min(0.5, max(0.0, deadline - time.monotonic()))
             time.sleep(sleep_for)
 
-    def kill(self) -> None:
-        """Destroy the sandbox immediately.
+    def kill(self, wait: bool = False, timeout: int = 300) -> None:
+        """Destroy the sandbox.
+
+        The backend accepts the delete with HTTP 202 and tears the sandbox
+        down asynchronously, including purging its persistence records. The
+        sandbox name stays reserved until that purge completes, so pass
+        ``wait=True`` when you intend to reuse the name (or need the quota
+        back) and must know the reclamation finished.
 
         After calling this method, the sandbox cannot be used anymore.
         Any subsequent calls to run_code(), commands, or files will raise.
 
         If the delete request fails, an exception is raised and the sandbox
         remains usable so callers can retry or handle the failure.
+
+        Args:
+            wait: Poll until the sandbox is really gone (default: False).
+            timeout: Maximum seconds to wait when ``wait`` is True.
+
+        Raises:
+            SandboxTimeoutError: If ``wait`` is True and the sandbox is still
+                present after ``timeout`` seconds.
         """
         if self._killed:
             return  # Already killed, nothing to do
         self._client.delete(self._name)
+        if wait:
+            self._wait_until_gone(timeout)
         # Only mark as killed and close client after successful delete
         self._status = SandboxStatus.SUCCEEDED
         self._killed = True
         self._client.close()
+
+    def _wait_until_gone(self, timeout: int) -> None:
+        """Poll the sandbox until the backend reports it as absent (404)."""
+        poll_interval = 2
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                info = self._client.get(self._name, request_timeout=remaining)
+            except NotFoundError:
+                return
+            except httpx.TimeoutException:
+                pass
+            else:
+                self._status = info.status
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(poll_interval, remaining))
+        raise SandboxTimeoutError(
+            f"Sandbox {self._name} was not deleted within {timeout}s "
+            f"(current phase: {self._status.value!r})"
+        )
 
     def refresh(self, request_timeout: float | None = None) -> None:
         """Refresh sandbox information from the API.
@@ -419,6 +522,7 @@ class Sandbox:
         self._check_not_killed()
         info = self._client.get(self._name, request_timeout=request_timeout)
         self._status = info.status
+        self._last_error = info.last_error
         if info.auto_idle_timeout_seconds is not None:
             self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
 
@@ -436,8 +540,9 @@ class Sandbox:
     ) -> Self:
         """Claim a sandbox from a warm pool.
 
-        This is the fastest way to get a sandbox - typically <100ms.
-        The sandbox is pre-warmed and ready to use immediately.
+        This is the fastest way to get a sandbox: the backend adopts a
+        pre-warmed pod, but does so asynchronously, so the claim starts out
+        in phase Pending. Call :meth:`wait_until_ready` before using it.
 
         Args:
             pool: Name of the warm pool.
@@ -449,10 +554,11 @@ class Sandbox:
             timeout: Request timeout (default: from PROKUBE_TIMEOUT env var).
 
         Returns:
-            A ready-to-use Sandbox instance.
+            A Sandbox instance, usually still starting up.
 
         Example:
             >>> sbx = Sandbox.from_pool("python-pool")
+            >>> sbx.wait_until_ready()
             >>> sbx.run_code("print('Hello!')")
         """
         config = cls._build_config(
@@ -578,7 +684,6 @@ class Sandbox:
     def list_page(
         cls,
         *,
-        lifecycle: Literal["active", "inactive"] = "active",
         limit: int = 25,
         continue_token: str | None = None,
         api_url: str | None = None,
@@ -589,8 +694,10 @@ class Sandbox:
     ) -> SandboxPage[Self]:
         """List one bounded page of sandboxes.
 
-        Pass ``continue_token`` from the previous page together with the same
-        ``lifecycle`` and ``limit`` values to fetch the next page.
+        One name-ordered listing covers every sandbox state. Pass
+        ``continue_token`` from the previous page together with the same
+        ``limit`` to fetch the next page; the token is an opaque keyset
+        cursor.
         """
         config = cls._build_config(
             api_url=api_url,
@@ -602,7 +709,6 @@ class Sandbox:
         client = SandboxClient(config)
         try:
             page = client.list_page(
-                lifecycle=lifecycle,
                 limit=limit,
                 continue_token=continue_token,
             )
@@ -728,10 +834,7 @@ class Sandbox:
             ...     env_vars=[{"name": "FOO", "value": "bar"}],
             ...     secret_refs=["openai-key"],
             ... )
-            >>> # Wait for sandbox to be ready
-            >>> while sbx.status == "Pending":
-            ...     time.sleep(1)
-            ...     sbx.refresh()
+            >>> sbx.wait_until_ready()
             >>> sbx.run_code("print('Ready!')")
         """
         config = cls._build_config(

--- a/tests/test_api_key_auth.py
+++ b/tests/test_api_key_auth.py
@@ -236,7 +236,8 @@ class TestApiKeyEndToEnd:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-abc", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-abc", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -272,7 +273,8 @@ class TestApiKeyEndToEnd:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -291,7 +293,8 @@ class TestApiKeyEndToEnd:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -311,7 +314,8 @@ class TestApiKeyEndToEnd:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool", api_key="explicit-key")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,7 +57,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -76,7 +76,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -124,7 +124,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -144,7 +144,6 @@ class TestListSandboxes:
 
         client = SandboxClient(config)
         page = client.list_page(
-            lifecycle="inactive",
             limit=10,
             continue_token="opaque-token",
         )
@@ -153,7 +152,6 @@ class TestListSandboxes:
         assert request.url.path == "/_platform/sandbox/test-ws/sandboxes"
         assert dict(request.url.params) == {
             "limit": "10",
-            "lifecycle": "inactive",
             "continueToken": "opaque-token",
         }
         assert [sandbox.name for sandbox in page.sandboxes] == ["paused-1"]
@@ -168,7 +166,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
 
         client = SandboxClient(config)
@@ -184,7 +182,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -195,7 +193,7 @@ class TestListSandboxes:
         client.list_page(continue_token="")
 
         request = httpx_mock.get_requests()[-1]
-        assert dict(request.url.params) == {"limit": "25", "lifecycle": "active"}
+        assert dict(request.url.params) == {"limit": "25"}
         client.close()
 
     def test_claim_sends_auto_idle_timeout(self, config, httpx_mock: HTTPXMock):
@@ -205,12 +203,13 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Pending"},
         )
 
         client = SandboxClient(config)
@@ -230,7 +229,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -254,7 +253,7 @@ class TestListSandboxes:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -288,7 +287,7 @@ class TestReadFile:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock file download - path is passed as query parameter
         httpx_mock.add_response(
@@ -309,7 +308,7 @@ class TestReadFile:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock file download - special chars in query param
         httpx_mock.add_response(
@@ -334,13 +333,14 @@ class TestUnknownStatusFromBackend:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim with unknown status
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "SomeNewBackendStatus"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "SomeNewBackendStatus"},
         )
 
         client = SandboxClient(config)
@@ -349,4 +349,117 @@ class TestUnknownStatusFromBackend:
         # Should fall back to UNKNOWN instead of crashing
         assert info.status == SandboxStatus.UNKNOWN
         assert info.name == "sandbox-test"
+        client.close()
+
+
+class TestClaimResponseShape:
+    """The claim endpoint returns a full Sandbox body (202), not a claim stub."""
+
+    def test_claim_parses_full_sandbox_body(self, config, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.8.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=202,
+            json={
+                "name": "claim-abc123",
+                "namespace": "test-ws",
+                "image": "python:3.12",
+                "phase": "Pending",
+                "podName": "pool-pod-7",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "poolName": "python-pool",
+                "claimName": "claim-abc123",
+                "autoIdleTimeoutSeconds": 600,
+                "lastError": None,
+            },
+        )
+
+        client = SandboxClient(config)
+        info = client.claim_from_pool("python-pool")
+
+        assert info.name == "claim-abc123"
+        assert info.status == SandboxStatus.PENDING
+        assert info.image == "python:3.12"
+        assert info.pool == "python-pool"
+        assert info.created_at == "2026-01-01T00:00:00Z"
+        assert info.auto_idle_timeout_seconds == 600
+        assert info.last_error is None
+        client.close()
+
+    def test_claim_defaults_missing_phase_to_pending(
+        self, config, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.8.0"},
+        )
+        httpx_mock.add_response(
+            method="POST",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
+            status_code=202,
+            json={"name": "claim-abc123", "namespace": "test-ws"},
+        )
+
+        client = SandboxClient(config)
+        info = client.claim_from_pool("python-pool")
+
+        assert info.status == SandboxStatus.PENDING
+        assert info.pool == "python-pool"
+        client.close()
+
+
+class TestLastError:
+    """``lastError`` is surfaced wherever the backend reports a Sandbox."""
+
+    def test_get_surfaces_last_error(self, config, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.8.0"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sbx-1",
+            json={
+                "name": "sbx-1",
+                "phase": "Failed",
+                "lastError": "resume failed: no capacity",
+            },
+        )
+
+        client = SandboxClient(config)
+        info = client.get("sbx-1")
+
+        assert info.status == SandboxStatus.FAILED
+        assert info.last_error == "resume failed: no capacity"
+        client.close()
+
+    def test_list_surfaces_last_error(self, config, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/api/version",
+            json={"version": "0.8.0"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="https://test.example.com/_platform/sandbox/test-ws/sandboxes",
+            json={
+                "sandboxes": [
+                    {"name": "sbx-1", "phase": "Failed", "lastError": "pause failed"},
+                    {"name": "sbx-2", "phase": "Running"},
+                ]
+            },
+        )
+
+        client = SandboxClient(config)
+        result = client.list()
+
+        assert result[0].last_error == "pause failed"
+        assert result[1].last_error is None
         client.close()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -62,6 +62,32 @@ class TestHttpClient:
         response = http_client.delete("/api/test")
         assert response is None
 
+    def test_delete_accepted_with_empty_body(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """The v0.8 backend answers DELETE with 202 and an empty body."""
+        httpx_mock.add_response(
+            method="DELETE",
+            url="https://test.example.com/api/test",
+            status_code=202,
+        )
+
+        assert http_client.delete("/api/test") is None
+
+    def test_delete_accepted_with_null_body(
+        self, http_client: HttpClient, httpx_mock: HTTPXMock
+    ):
+        """A literal ``null`` JSON body is also treated as no content."""
+        httpx_mock.add_response(
+            method="DELETE",
+            url="https://test.example.com/api/test",
+            status_code=202,
+            content=b"null",
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert http_client.delete("/api/test") is None
+
     def test_get_bytes(self, http_client: HttpClient, httpx_mock: HTTPXMock):
         """Test GET request returning bytes."""
         httpx_mock.add_response(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,10 @@ class TestSandboxStatus:
         """Test status enum values."""
         assert SandboxStatus.PENDING.value == "Pending"
         assert SandboxStatus.RUNNING.value == "Running"
-        assert SandboxStatus.BOUND.value == "Bound"
+        assert SandboxStatus.PAUSED.value == "Paused"
+        assert SandboxStatus.PAUSING.value == "Pausing"
+        assert SandboxStatus.RESUMING.value == "Resuming"
+        assert SandboxStatus.DELETING.value == "Deleting"
         assert SandboxStatus.SUCCEEDED.value == "Succeeded"
         assert SandboxStatus.FAILED.value == "Failed"
         assert SandboxStatus.UNKNOWN.value == "Unknown"
@@ -43,6 +46,7 @@ class TestSandboxInfo:
         assert info.status == SandboxStatus.UNKNOWN
         assert info.image is None
         assert info.pool is None
+        assert info.last_error is None
 
     def test_full_sandbox_info(self):
         """Test creating SandboxInfo with all fields."""
@@ -54,11 +58,13 @@ class TestSandboxInfo:
             pool="my-pool",
             created_at="2024-01-01T00:00:00Z",
             auto_idle_timeout_seconds=1800,
+            last_error="pause failed: csi timeout",
         )
         assert info.status == SandboxStatus.RUNNING
         assert info.image == "python:3.10"
         assert info.pool == "my-pool"
         assert info.auto_idle_timeout_seconds == 1800
+        assert info.last_error == "pause failed: csi timeout"
 
 
 class TestCommandResult:

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -78,7 +78,7 @@ def config():
 
 
 BASE = "https://test.example.com"
-VERSION_RESPONSE = {"version": "0.1.0"}
+VERSION_RESPONSE = {"version": "0.8.0"}
 
 
 def _mock_version(httpx_mock: HTTPXMock):
@@ -87,16 +87,43 @@ def _mock_version(httpx_mock: HTTPXMock):
     )
 
 
-def _mock_claim(httpx_mock: HTTPXMock, name="sandbox-test", status="Running"):
+def _mock_claim(httpx_mock: HTTPXMock, name="sandbox-test", phase="Running"):
+    """Mock the claim endpoint with the v0.8 202 + full Sandbox body."""
     httpx_mock.add_response(
         method="POST",
         url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/claim",
-        json={"name": name, "status": status},
+        status_code=202,
+        json={
+            "name": name,
+            "namespace": "test-ws",
+            "phase": phase,
+            "poolName": "python-pool",
+            "claimName": f"{name}-claim",
+            "lastError": None,
+        },
+    )
+
+
+def _mock_pause(httpx_mock: HTTPXMock, name="sandbox-test", phase="Pausing"):
+    """Mock the pause endpoint with the v0.8 202 + full Sandbox body."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/{name}/pause",
+        status_code=202,
+        json={"name": name, "namespace": "test-ws", "phase": phase},
+    )
+
+
+def _mock_get(httpx_mock: HTTPXMock, phase, name="sandbox-test", **extra):
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/{name}",
+        json={"name": name, "phase": phase, **extra},
     )
 
 
 class TestPausedStatus:
-    """Tests for Paused status enum."""
+    """Tests for the lifecycle status enum."""
 
     def test_paused_status_exists(self):
         assert SandboxStatus.PAUSED.value == "Paused"
@@ -104,25 +131,35 @@ class TestPausedStatus:
     def test_parse_paused_status(self):
         assert _parse_status("Paused", SandboxStatus.UNKNOWN) == SandboxStatus.PAUSED
 
+    @pytest.mark.parametrize(
+        ("wire", "expected"),
+        [
+            ("Pausing", SandboxStatus.PAUSING),
+            ("Resuming", SandboxStatus.RESUMING),
+            ("Deleting", SandboxStatus.DELETING),
+        ],
+    )
+    def test_parse_transitional_phases(self, wire, expected):
+        assert _parse_status(wire, SandboxStatus.UNKNOWN) == expected
+        assert expected.value == wire
+
 
 class TestClientPause:
     """Tests for SandboxClient.pause()."""
 
-    def test_pause_success(self, config, httpx_mock: HTTPXMock):
+    def test_pause_returns_pausing_sandbox(self, config, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/pause",
-            json={"status": "ok"},
-        )
+        _mock_pause(httpx_mock, name="my-sandbox")
 
         client = SandboxClient(config)
-        client.pause("my-sandbox")
+        info = client.pause("my-sandbox")
 
         requests = httpx_mock.get_requests()
         pause_req = [r for r in requests if "/pause" in str(r.url)]
         assert len(pause_req) == 1
         assert pause_req[0].method == "POST"
+        assert info.name == "my-sandbox"
+        assert info.status == SandboxStatus.PAUSING
         client.close()
 
     def test_pause_conflict_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
@@ -150,7 +187,8 @@ class TestClientResume:
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
-            json={"name": "my-sandbox", "phase": "Pending", "resumedFromPool": False},
+            status_code=202,
+            json={"name": "my-sandbox", "namespace": "test-ws", "phase": "Resuming"},
         )
 
         client = SandboxClient(config)
@@ -161,75 +199,7 @@ class TestClientResume:
         assert len(resume_req) == 1
         assert resume_req[0].method == "POST"
         assert info.name == "my-sandbox"
-        assert info.status == SandboxStatus.PENDING
-        assert info.resumed_from_pool is False
-        client.close()
-
-    def test_resume_legacy_ok_status_defaults_to_pending(
-        self, config, httpx_mock: HTTPXMock
-    ):
-        _mock_version(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
-            json={"status": "ok"},
-        )
-
-        client = SandboxClient(config)
-        info = client.resume("my-sandbox")
-
-        assert info.name == "my-sandbox"
-        assert info.status == SandboxStatus.PENDING
-        assert info.resumed_from_pool is False
-        client.close()
-
-    def test_resume_parses_pool_resume_hint(self, config, httpx_mock: HTTPXMock):
-        _mock_version(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
-            json={"name": "my-sandbox", "phase": "Running", "resumedFromPool": True},
-        )
-
-        client = SandboxClient(config)
-        info = client.resume("my-sandbox")
-
-        assert info.status == SandboxStatus.RUNNING
-        assert info.resumed_from_pool is True
-        client.close()
-
-    def test_resume_parses_snake_case_pool_resume_hint(
-        self, config, httpx_mock: HTTPXMock
-    ):
-        _mock_version(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
-            json={"name": "my-sandbox", "phase": "Running", "resumed_from_pool": True},
-        )
-
-        client = SandboxClient(config)
-        info = client.resume("my-sandbox")
-
-        assert info.status == SandboxStatus.RUNNING
-        assert info.resumed_from_pool is True
-        client.close()
-
-    def test_resume_coalesces_null_pool_resume_hint(
-        self, config, httpx_mock: HTTPXMock
-    ):
-        _mock_version(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/my-sandbox/resume",
-            json={"name": "my-sandbox", "phase": "Running", "resumedFromPool": None},
-        )
-
-        client = SandboxClient(config)
-        info = client.resume("my-sandbox")
-
-        assert info.status == SandboxStatus.RUNNING
-        assert info.resumed_from_pool is False
+        assert info.status == SandboxStatus.RESUMING
         client.close()
 
     def test_resume_conflict_raises_sandbox_error(self, config, httpx_mock: HTTPXMock):
@@ -252,20 +222,93 @@ class TestClientResume:
 class TestSandboxPause:
     """Tests for Sandbox.pause()."""
 
-    def test_pause_running_sandbox(self, mock_env, httpx_mock: HTTPXMock):
+    def test_pause_waits_until_paused(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """pause() blocks by default and polls the async Pausing -> Paused hop."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
-            json={"status": "ok"},
-        )
+        _mock_pause(httpx_mock)
+        _mock_get(httpx_mock, "Pausing")
+        _mock_get(httpx_mock, "Paused")
 
         sbx = Sandbox.from_pool("python-pool")
         assert sbx.status == "Running"
 
         sbx.pause()
         assert sbx.status == "Paused"
+
+        polls = [
+            r
+            for r in httpx_mock.get_requests()
+            if r.method == "GET" and str(r.url).endswith("/sandboxes/sandbox-test")
+        ]
+        assert len(polls) == 2
+
+        sbx._client.close()
+
+    def test_pause_without_wait_reports_pausing(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.pause(wait=False)
+
+        assert sbx.status == "Pausing"
+        polls = [
+            r
+            for r in httpx_mock.get_requests()
+            if r.method == "GET" and str(r.url).endswith("/sandboxes/sandbox-test")
+        ]
+        assert not polls
+
+        sbx._client.close()
+
+    def test_pause_failure_raises_with_last_error(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+        _mock_get(httpx_mock, "Pausing")
+        _mock_get(httpx_mock, "Failed", lastError="pvc snapshot rejected by CSI driver")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(
+            SandboxError, match="pvc snapshot rejected by CSI driver"
+        ) as excinfo:
+            sbx.pause()
+        assert "re-issue pause()" in str(excinfo.value)
+
+        sbx._client.close()
+
+    @pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+    def test_pause_wait_timeout_raises(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        call_count = 0
+        real_monotonic = __import__("time").monotonic
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return real_monotonic()
+            return real_monotonic() + 1000
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+        _mock_get(httpx_mock, "Pausing")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxTimeoutError, match="did not pause within"):
+            sbx.pause(timeout=1)
 
         sbx._client.close()
 
@@ -293,7 +336,7 @@ class TestSandboxPause:
         httpx_mock.add_response(
             method="DELETE",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            status_code=204,
+            status_code=202,
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -309,71 +352,20 @@ class TestSandboxResume:
     def test_resume_paused_sandbox(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
-        # Pause first
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
-            json={"status": "ok"},
-        )
-        # Resume
+        _mock_pause(httpx_mock)
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
-            json={"name": "sandbox-test", "phase": "Pending", "resumedFromPool": False},
+            status_code=202,
+            json={"name": "sandbox-test", "namespace": "test-ws", "phase": "Resuming"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
-        sbx.pause()
-        assert sbx.status == "Paused"
+        sbx.pause(wait=False)
+        assert sbx.status == "Pausing"
 
         sbx.resume()
-        assert sbx.status == "Pending"
-
-        sbx._client.close()
-
-    def test_resume_from_pool_skips_wait_warmup(
-        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
-    ):
-        monkeypatch.setattr("time.sleep", lambda _: None)
-        _mock_version(httpx_mock)
-        _mock_claim(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
-            json={"status": "ok"},
-        )
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
-            json={"name": "sandbox-test", "phase": "Running", "resumedFromPool": True},
-        )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Running"},
-        )
-
-        sbx = Sandbox.from_pool("python-pool")
-        sbx.pause()
-        sbx.resume()
-
-        assert sbx.status == "Running"
-        sbx.wait_until_ready(timeout=5)
-
-        requests = httpx_mock.get_requests()
-        get_requests = [
-            r
-            for r in requests
-            if r.method == "GET" and "/sandboxes/sandbox-test" in str(r.url)
-        ]
-        exec_requests = [
-            r
-            for r in requests
-            if r.method == "POST"
-            and str(r.url).endswith("/sandboxes/sandbox-test/exec")
-        ]
-        assert len(get_requests) == 1
-        assert not exec_requests
+        assert sbx.status == "Resuming"
 
         sbx._client.close()
 
@@ -382,19 +374,16 @@ class TestSandboxResume:
     ):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
-        httpx_mock.add_response(
-            method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
-            json={"status": "ok"},
-        )
+        _mock_pause(httpx_mock)
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
-            json={"name": "sandbox-test", "phase": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Resuming"},
         )
 
         sbx = Sandbox.from_pool("python-pool", auto_idle_timeout_seconds=900)
-        sbx.pause()
+        sbx.pause(wait=False)
         sbx.resume()
 
         assert sbx.auto_idle_timeout_seconds == 900
@@ -467,39 +456,35 @@ class TestWaitUntilReady:
 
         sbx._client.close()
 
-    def test_wait_until_ready_pool_resume_requires_confirmed_running(
+    def test_wait_until_ready_polls_through_resuming(
         self, mock_env, monkeypatch, httpx_mock: HTTPXMock
     ):
+        """Transitional phases are not terminal: keep polling until Running."""
         monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="POST",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/pause",
-            json={"status": "ok"},
-        )
-        httpx_mock.add_response(
-            method="POST",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
-            json={"name": "sandbox-test", "phase": "Paused", "resumedFromPool": True},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Resuming"},
         )
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Running"},
-        )
+        _mock_get(httpx_mock, "Resuming")
+        _mock_get(httpx_mock, "Running")
+        _mock_warmup_probe_success(httpx_mock)
+
         sbx = Sandbox.from_pool("python-pool")
-        sbx.pause()
         sbx.resume()
+        assert sbx.status == "Resuming"
         sbx.wait_until_ready(timeout=10)
 
-        requests = httpx_mock.get_requests()
+        assert sbx.status == "Running"
         get_requests = [
             r
-            for r in requests
-            if r.method == "GET" and "/sandboxes/sandbox-test" in str(r.url)
+            for r in httpx_mock.get_requests()
+            if r.method == "GET" and str(r.url).endswith("/sandboxes/sandbox-test")
         ]
-        assert len(get_requests) == 1
+        assert len(get_requests) == 2
         sbx._client.close()
 
     def test_wait_until_ready_warms_kernel_on_cold_start(
@@ -892,18 +877,118 @@ class TestWaitUntilReady:
 
         sbx._client.close()
 
-    def test_wait_until_ready_terminal_state(self, mock_env, httpx_mock: HTTPXMock):
+    def test_wait_until_ready_failed_includes_last_error(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
-        httpx_mock.add_response(
-            method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "phase": "Failed"},
+        _mock_get(
+            httpx_mock, "Failed", lastError="image pull backoff: manifest unknown"
         )
 
         sbx = Sandbox.from_pool("python-pool")
-        with pytest.raises(SandboxError, match="terminal state"):
+        with pytest.raises(
+            SandboxError, match="image pull backoff: manifest unknown"
+        ) as excinfo:
             sbx.wait_until_ready(timeout=10)
+        assert "terminal state" in str(excinfo.value)
+
+        sbx._client.close()
+
+    def test_wait_until_ready_deleting_raises(self, mock_env, httpx_mock: HTTPXMock):
+        """A sandbox being torn down can never become ready."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Deleting")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxError, match="'Deleting'"):
+            sbx.wait_until_ready(timeout=10)
+
+        sbx._client.close()
+
+
+class TestSandboxKill:
+    """Tests for the asynchronous Sandbox.kill()."""
+
+    def test_kill_does_not_poll_by_default(self, mock_env, httpx_mock: HTTPXMock):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=202,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.kill()
+
+        assert not [
+            r
+            for r in httpx_mock.get_requests()
+            if r.method == "GET" and "/api/" not in str(r.url)
+        ]
+
+    def test_kill_wait_polls_until_gone(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """kill(wait=True) polls the sandbox until the backend returns 404."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=202,
+        )
+        _mock_get(httpx_mock, "Deleting")
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=404,
+            json={"detail": "not found"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.kill(wait=True)
+
+        polls = [
+            r
+            for r in httpx_mock.get_requests()
+            if r.method == "GET" and str(r.url).endswith("/sandboxes/sandbox-test")
+        ]
+        assert len(polls) == 2
+        with pytest.raises(SandboxError, match="has been killed"):
+            sbx.run_code("print(1)")
+
+    @pytest.mark.httpx_mock(can_send_already_matched_responses=True)
+    def test_kill_wait_timeout_raises(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        call_count = 0
+        real_monotonic = __import__("time").monotonic
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return real_monotonic()
+            return real_monotonic() + 1000
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=202,
+        )
+        _mock_get(httpx_mock, "Deleting")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxTimeoutError, match="was not deleted within"):
+            sbx.kill(wait=True, timeout=1)
 
         sbx._client.close()
 

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -312,6 +312,44 @@ class TestSandboxPause:
 
         sbx._client.close()
 
+    def test_pause_wait_deleting_raises(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A delete admitted during the pause outranks it; stop waiting."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+        _mock_get(httpx_mock, "Pausing")
+        _mock_get(httpx_mock, "Deleting")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxError, match="is being deleted"):
+            sbx.pause()
+
+        sbx._client.close()
+
+    def test_pause_wait_sandbox_gone_raises(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A concurrent delete finishing mid-wait surfaces as SandboxError."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=404,
+            json={"detail": "not found"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxError, match="deleted while waiting"):
+            sbx.pause()
+
+        sbx._client.close()
+
     def test_pause_non_running_raises(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
@@ -991,6 +1029,82 @@ class TestSandboxKill:
             sbx.kill(wait=True, timeout=1)
 
         sbx._client.close()
+
+    def test_kill_wait_delete_failed_raises_with_last_error(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A terminal delete_failed row surfaces immediately, with the reason."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=202,
+        )
+        _mock_get(httpx_mock, "Deleting")
+        _mock_get(
+            httpx_mock, "Failed", lastError="workspace purge could not be confirmed"
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(
+            SandboxError,
+            match=r"failed to delete: workspace purge could not be confirmed",
+        ):
+            sbx.kill(wait=True)
+
+        # The delete was admitted and terminally failed: the object must not
+        # accept work, but kill() stays re-issuable.
+        with pytest.raises(SandboxError, match="is being deleted"):
+            sbx.run_code("print(1)")
+        sbx._client.close()
+
+    def test_kill_wait_timeout_blocks_operations_and_kill_retries(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """After a wait timeout the object is deletion-locked; kill() retries."""
+        call_count = 0
+        real_monotonic = __import__("time").monotonic
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return real_monotonic()
+            return real_monotonic() + 1000
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=202,
+        )
+        _mock_get(httpx_mock, "Deleting")
+
+        sbx = Sandbox.from_pool("python-pool")
+        with pytest.raises(SandboxTimeoutError, match="was not deleted within"):
+            sbx.kill(wait=True, timeout=1)
+
+        # Deletion was admitted: normal operations are blocked...
+        with pytest.raises(SandboxError, match="is being deleted"):
+            sbx.run_code("print(1)")
+
+        # ...but kill() can be re-issued; a 404 on the re-issued DELETE means
+        # the backend finished in the meantime, which is the desired outcome.
+        httpx_mock.add_response(
+            method="DELETE",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            status_code=404,
+            json={"detail": "not found"},
+        )
+        sbx.kill(wait=True)
+        assert sbx.status == "Succeeded"
+        with pytest.raises(SandboxError, match="has been killed"):
+            sbx.run_code("print(1)")
 
 
 class TestSandboxPhaseProperty:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -68,7 +68,7 @@ class TestPoolClientPathRouting:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -112,7 +112,7 @@ class TestPoolClientCreate:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -159,7 +159,7 @@ class TestPoolClientCreateExtras:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -191,7 +191,7 @@ class TestPoolClientCreateExtras:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -298,7 +298,7 @@ class TestPoolClientList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -315,7 +315,7 @@ class TestPoolClientList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -363,7 +363,7 @@ class TestPoolClientGet:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -388,7 +388,7 @@ class TestPoolClientDelete:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="DELETE",
@@ -415,7 +415,7 @@ def _mock_version(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(
         method="GET",
         url="https://test.example.com/api/version",
-        json={"version": "0.1.0"},
+        json={"version": "0.8.0"},
     )
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -312,6 +312,7 @@ class TestSandboxCreate:
         for key in (
             "cpu",
             "memory",
+            "resources",
             "allowInternetAccess",
             "autoIdleTimeoutSeconds",
             "envVars",
@@ -322,8 +323,9 @@ class TestSandboxCreate:
         sbx._client.close()
 
     def test_create_sandbox_with_all_extras(self, mock_env, httpx_mock: HTTPXMock):
-        """cpu/memory/allow_internet_access/env_vars/secret_refs should serialize
-        to camelCase JSON keys on the wire."""
+        """cpu/memory serialize BOTH flat (external API-key route) and nested
+        under `resources` (internal route) — each backend route reads its own
+        shape and ignores the other."""
         import json
 
         httpx_mock.add_response(
@@ -354,6 +356,7 @@ class TestSandboxCreate:
         body = json.loads(post_req.content)
         assert body["image"] == "python:3.10"
         assert body["name"] == "sandbox-abc"
+        assert body["resources"] == {"cpu": "2", "memory": "4Gi"}
         assert body["cpu"] == "2"
         assert body["memory"] == "4Gi"
         assert body["allowInternetAccess"] is True

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -27,7 +27,7 @@ class TestSandboxList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -45,7 +45,7 @@ class TestSandboxList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -89,7 +89,7 @@ class TestSandboxList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -121,7 +121,7 @@ class TestSandboxList:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -145,7 +145,7 @@ class TestSandboxList:
 
         monkeypatch.setattr(SandboxClient, "close", spy_close)
 
-        with Sandbox.list_page(lifecycle="inactive", limit=10) as page:
+        with Sandbox.list_page(limit=10) as page:
             assert isinstance(page, SandboxPage)
             assert [sandbox.name for sandbox in page.sandboxes] == [
                 "paused-1",
@@ -171,7 +171,7 @@ class TestSandboxList:
         ]
 
         request = httpx_mock.get_requests()[-1]
-        assert dict(request.url.params) == {"limit": "10", "lifecycle": "inactive"}
+        assert dict(request.url.params) == {"limit": "10"}
 
 
 class TestSandboxFromPool:
@@ -183,13 +183,14 @@ class TestSandboxFromPool:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim request
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-abc123", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-abc123", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -220,12 +221,13 @@ class TestSandboxFromPool:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-abc123", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-abc123", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool", auto_idle_timeout_seconds=900)
@@ -241,7 +243,7 @@ class TestSandboxFromPool:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -268,7 +270,7 @@ class TestSandboxCreate:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock create request
         httpx_mock.add_response(
@@ -293,7 +295,7 @@ class TestSandboxCreate:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -327,7 +329,7 @@ class TestSandboxCreate:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -377,7 +379,7 @@ class TestSandboxCreate:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -407,13 +409,14 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock exec
         httpx_mock.add_response(
@@ -443,12 +446,13 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -477,12 +481,13 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -512,12 +517,13 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -547,13 +553,14 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # First exec - returns session_id
         httpx_mock.add_response(
@@ -615,13 +622,14 @@ class TestSandboxRunCode:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # First exec
         httpx_mock.add_response(
@@ -683,13 +691,14 @@ class TestSandboxCommands:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock exec
         httpx_mock.add_response(
@@ -719,12 +728,13 @@ class TestSandboxCommands:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -753,12 +763,13 @@ class TestSandboxCommands:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -787,12 +798,13 @@ class TestSandboxCommands:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -821,12 +833,13 @@ class TestSandboxCommands:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -858,13 +871,14 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock file write
         httpx_mock.add_response(
@@ -901,12 +915,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -978,7 +993,8 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -1015,12 +1031,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -1067,12 +1084,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         httpx_mock.add_response(
             method="POST",
@@ -1083,7 +1101,7 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            json={"name": "sandbox-test", "status": "Running"},
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -1100,12 +1118,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -1125,12 +1144,13 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -1151,13 +1171,14 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock file read - uses /files/download?path= endpoint
         httpx_mock.add_response(
@@ -1179,13 +1200,14 @@ class TestSandboxFiles:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock file list
         httpx_mock.add_response(
@@ -1219,19 +1241,20 @@ class TestSandboxKill:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock delete
         httpx_mock.add_response(
             method="DELETE",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            status_code=204,
+            status_code=202,
         )
 
         sbx = Sandbox.from_pool("python-pool")
@@ -1249,19 +1272,20 @@ class TestSandboxContextManager:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
         # Mock delete
         httpx_mock.add_response(
             method="DELETE",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/sandbox-test",
-            status_code=204,
+            status_code=202,
         )
 
         with Sandbox.from_pool("python-pool") as sbx:
@@ -1282,13 +1306,14 @@ class TestSandboxRepr:
         httpx_mock.add_response(
             method="GET",
             url="https://test.example.com/api/version",
-            json={"version": "0.1.0"},
+            json={"version": "0.8.0"},
         )
         # Mock claim
         httpx_mock.add_response(
             method="POST",
             url="https://test.example.com/_platform/sandbox/test-ws/sandboxes/claim",
-            json={"name": "sandbox-test", "status": "Running"},
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Running"},
         )
 
         sbx = Sandbox.from_pool("python-pool")


### PR DESCRIPTION
Follow-up to prokube/pk-sandbox#91 (v0.8 Postgres-orchestrated lifecycle). The backend's mutations are now admission-only — 202 + a full `Sandbox` body everywhere, transitional phases until the in-backend worker settles, `Failed` + `lastError` on terminal failures (retry = re-issue the op). This release follows, as a clean cutover: **no back-compat with pre-0.8 backends** (`MIN_BACKEND_VERSION = 0.8.0`), version bumped to **0.2.0**.

## API changes

| Surface | v0.1.x | v0.2.0 |
|---|---|---|
| `SandboxStatus` | `Bound` (dead) | `Pausing`, `Resuming`, `Deleting` added; `Bound` removed |
| `SandboxInfo` | `resumed_from_pool` | removed; `last_error` added (wire `lastError`) |
| `client.claim_from_pool` | parsed `ClaimSandboxResponse` (`sandboxName`/`status`) | parses the same `Sandbox` body as create (phase starts `Pending`) |
| `client.pause` | `None` | `SandboxInfo` (phase `Pausing`) |
| `client.resume` | pool-swap hint plumbing | plain `SandboxInfo` (phase `Resuming`) |
| `Sandbox.pause()` | synchronous on the backend | `pause(wait=True, timeout=300)` polls to `Paused`; `Failed` ⇒ `SandboxError` carrying `lastError` (re-issue `pause()` to retry) |
| `Sandbox.kill()` | delete was synchronous | `kill(wait=True)` polls to 404 — deletion incl. the persistence purge is async and the name stays reserved until the purge completes |
| `wait_until_ready()` | terminal on `Failed`/`Succeeded` | also `Deleting`; error message carries `lastError`; polls through `Resuming` |
| `list_page` | `lifecycle="active"\|"inactive"` | parameter removed — v0.8 serves one name-ordered keyset list across every state |

Default `pause(wait=True)` deliberately preserves v0.7 call-site semantics (pause returned when the checkpoint was verified), so existing user code keeps its meaning; `wait=False` exposes the raw 202.

## Verification

- **Live end-to-end smoke against a deployed v0.8 backend** (current-tarsier, `pk-sandbox-backend:v08-d84f6a3`) with this branch:
  ```
  create 202 -> status=Pending (0.2s)
  ready (17.7s)                       # wait_until_ready
  run_code ok: 42
  paused, status=Paused (22.8s)       # pause() blocked to Paused
  resume 202 -> status=Resuming
  resumed+exec ok (44.2s)             # wait_until_ready polled through Resuming
  killed and gone (48.3s)             # kill(wait=True) polled to 404
  ```
- 214 tests passing (baseline 203). New coverage: 202 `Sandbox` bodies on all four mutations, transitional-phase parsing, `lastError` surfaced by get/list and carried into `SandboxError`, `pause` wait/failure/timeout paths, `kill(wait=True)` polling to 404, `wait_until_ready` through `Resuming` and terminal on `Failed`/`Deleting`, DELETE 202 with empty and literal-`null` bodies.
- `ruff check` + `ruff format --check` clean.
- Wire shapes verified against the backend source (pk-sandbox `routes.py:871-1156`, `models.py:389-420` on `feat/claim-only-backend`).
