### PR TITLE
feat(sandbox): long-poll wait_until_ready and single-call kernel warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,20 @@ print(result.exit_code)
 
 # File operations
 sbx.files.write("/workspace/data.csv", b"col1,col2\n1,2\n3,4")
-batch_result = sbx.files.write_batch([
-    ("/workspace/app.py", "print('hello')"),
-    ("/workspace/data.bin", b"\x00\x01"),
-])
+batch_result = sbx.files.write_batch(
+    [
+        ("/workspace/app.py", "print('hello')"),
+        ("/workspace/data.bin", b"\x00\x01"),
+    ]
+)
 assert batch_result.success
 content = sbx.files.read("/workspace/output.txt")
 files = sbx.files.list("/workspace")
 
 # Pause / resume: both are asynchronous on the backend.
-sbx.pause()               # blocks until the sandbox reports Paused
-sbx.resume()              # returns immediately, phase is Resuming
-sbx.wait_until_ready()    # block until the new pod is Running
+sbx.pause()  # blocks until the sandbox reports Paused
+sbx.resume()  # returns immediately, phase is Resuming
+sbx.wait_until_ready()  # block until the new pod is Running
 
 # Cleanup. Deletion (including the persistence purge that releases the name)
 # is asynchronous; pass wait=True when you need guaranteed reclamation.
@@ -170,15 +172,15 @@ The main class for interacting with sandboxes.
 
 ```python
 class Sandbox:
-    name: str           # Sandbox name
-    workspace: str      # Workspace (Kubernetes namespace)
-    status: str         # Pending, Running, Paused, Pausing, Resuming,
-                        # Deleting, Succeeded, Failed, Unknown
-    
+    name: str  # Sandbox name
+    workspace: str  # Workspace (Kubernetes namespace)
+    status: str  # Pending, Running, Paused, Pausing, Resuming,
+    # Deleting, Succeeded, Failed, Unknown
+
     @classmethod
     def from_pool(cls, pool: str, **config) -> Sandbox:
         """Claim sandbox from WarmPool (fast; poll with wait_until_ready)."""
-    
+
     @classmethod
     def create(cls, image: str, **config) -> Sandbox:
         """Create sandbox directly (cold start)."""
@@ -196,10 +198,12 @@ class Sandbox:
         timeout: int | None = None,
     ) -> SandboxPage:
         """List one bounded page of sandboxes, across every phase."""
-    
-    def run_code(self, code: str, language: str = "python", timeout: int = 300) -> CodeResult:
+
+    def run_code(
+        self, code: str, language: str = "python", timeout: int = 300
+    ) -> CodeResult:
         """Execute code with stateful Jupyter kernel."""
-    
+
     def pause(self, wait: bool = True, timeout: int = 300) -> None:
         """Pause the sandbox; blocks until it reports Paused by default."""
 
@@ -211,11 +215,11 @@ class Sandbox:
 
     def kill(self, wait: bool = False, timeout: int = 300) -> None:
         """Destroy the sandbox; deletion completes asynchronously."""
-    
+
     @property
     def commands(self) -> CommandRunner:
         """Access shell command runner."""
-    
+
     @property
     def files(self) -> FileManager:
         """Access file operations."""
@@ -251,12 +255,13 @@ class CommandRunner:
     def run(self, command: str, timeout: int = 300) -> CommandResult:
         """Execute shell command."""
 
+
 class CommandResult(BaseModel):  # Pydantic model
     stdout: str
     stderr: str
     exit_code: int
     duration_ms: int
-    
+
     @property
     def success(self) -> bool: ...
 ```
@@ -268,7 +273,9 @@ class FileManager:
     def write(self, path: str, content: bytes | str) -> None:
         """Upload file to sandbox."""
 
-    def write_batch(self, items: list[tuple[str, bytes | str]]) -> BatchFileWriteResponse:
+    def write_batch(
+        self, items: list[tuple[str, bytes | str]]
+    ) -> BatchFileWriteResponse:
         """Best-effort batch upload with per-file results."""
 
     def read(self, path: str) -> bytes:
@@ -279,18 +286,18 @@ class FileManager:
 
 
 class BatchFileWriteResponse(BaseModel):
-    success: bool           # True only if every file write succeeded
-    total: int              # Total requested file writes
-    success_count: int      # Number of successful writes
-    failure_count: int      # Number of failed writes
+    success: bool  # True only if every file write succeeded
+    total: int  # Total requested file writes
+    success_count: int  # Number of successful writes
+    failure_count: int  # Number of failed writes
     results: list[BatchFileWriteResult]
 
 
 class BatchFileWriteResult(BaseModel):
-    index: int              # Original request position
-    path: str               # Sandbox path for this entry
-    success: bool           # Whether this file write succeeded
-    error: str | None       # Failure detail for best-effort partial failures
+    index: int  # Original request position
+    path: str  # Sandbox path for this entry
+    success: bool  # Whether this file write succeeded
+    error: str | None  # Failure detail for best-effort partial failures
 ```
 
 ### CodeResult
@@ -301,10 +308,10 @@ class CodeResult(BaseModel):  # Pydantic model
     stderr: str
     success: bool
     execution_time_ms: int
-    error_name: str | None      # Set on failure
-    error_value: str | None     # Set on failure
-    traceback: list[str] | None # Set on failure
-    session_id: str | None      # For stateful execution
+    error_name: str | None  # Set on failure
+    error_value: str | None  # Set on failure
+    traceback: list[str] | None  # Set on failure
+    session_id: str | None  # For stateful execution
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prokube-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for prokube.ai platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prokube/_version.py
+++ b/src/prokube/_version.py
@@ -1,3 +1,3 @@
 """Version information for prokube-sdk."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -196,6 +196,16 @@ def _is_timeout_stderr(value: str) -> bool:
     )
 
 
+# Long-poll status GET (``?wait_phase=&timeout=``) tuning. The backend caps
+# the hold at 30s and defaults to 20s; the SDK mirrors those numbers so it
+# never asks for a window the backend will silently shorten. The margin is
+# how much longer than the hold a request is allowed to take, covering the
+# round trip of a response that only arrives when the hold expires.
+_DEFAULT_WAIT_TIMEOUT_SECONDS = 20
+_MAX_WAIT_TIMEOUT_SECONDS = 30
+_WAIT_REQUEST_MARGIN_SECONDS = 5
+
+
 class SandboxClient:
     """Client for sandbox API operations."""
 
@@ -376,7 +386,13 @@ class SandboxClient:
             continue_token=response.get("continueToken"),
         )
 
-    def get(self, name: str, request_timeout: float | None = None) -> SandboxInfo:
+    def get(
+        self,
+        name: str,
+        request_timeout: float | None = None,
+        wait_phase: str | None = None,
+        wait_timeout: float | None = None,
+    ) -> SandboxInfo:
         """Get information about a sandbox.
 
         This is the poll target for every asynchronous lifecycle operation.
@@ -389,15 +405,79 @@ class SandboxClient:
                 deadline (e.g. ``wait_until_ready``) should pass the
                 remaining budget so a single stalled request cannot outlast
                 the caller's overall timeout.
+            wait_phase: Optional phase to long-poll for (e.g. ``"Running"``).
+                When given, the backend holds the request open until the
+                sandbox reaches that phase or its own wait window elapses,
+                and answers with the current payload either way — a response
+                that still reports another phase is a normal timeout, not an
+                error. Backends that predate the parameter ignore it and
+                answer immediately, which degrades to plain polling.
+            wait_timeout: How long, in seconds, the backend may hold the
+                request when ``wait_phase`` is set. Defaults to
+                ``_DEFAULT_WAIT_TIMEOUT_SECONDS`` and is clamped to the
+                server-side cap.
 
         Returns:
             Information about the sandbox.
         """
-        kwargs: dict[str, float] = {}
+        kwargs: dict[str, object] = {}
         if request_timeout is not None:
             kwargs["timeout"] = request_timeout
+        if wait_phase is not None:
+            hold = int(
+                min(
+                    _MAX_WAIT_TIMEOUT_SECONDS,
+                    _DEFAULT_WAIT_TIMEOUT_SECONDS
+                    if wait_timeout is None
+                    else wait_timeout,
+                )
+            )
+            if request_timeout is not None:
+                # The server holds the connection for the whole wait window
+                # before answering, so the per-request timeout must outlast
+                # it — same reasoning as the request_timeout cap above, in
+                # the other direction. Leave a margin for the response trip
+                # so a long-poll that answers right at its cap still lands.
+                # Once too little budget is left to hold anything, fall back
+                # to a plain (immediate) status GET.
+                hold = min(hold, int(request_timeout) - _WAIT_REQUEST_MARGIN_SECONDS)
+            if hold >= 1:
+                kwargs["params"] = {"wait_phase": wait_phase, "timeout": hold}
         response = self._http.get(self._sandbox_path(name), **kwargs)
         return _parse_sandbox_info(response, self.config.workspace)
+
+    def ping_kernel(
+        self,
+        name: str,
+        wait_timeout: int,
+        request_timeout: float | None = None,
+    ) -> None:
+        """Block on the sandbox agent until its Jupyter kernel is warm.
+
+        Calls ``GET <sandbox>/ping?wait=kernel&timeout=<wait_timeout>`` on
+        the sandbox agent (the same per-sandbox base path ``exec`` uses, so
+        it is proxied exactly like code execution). Returning normally means
+        the agent answered 200 — the kernel has started.
+
+        Args:
+            name: Sandbox name.
+            wait_timeout: Seconds the agent may block waiting for the kernel.
+            request_timeout: Optional per-request timeout override.
+
+        Raises:
+            NotFoundError: The agent (or the proxy in front of it) does not
+                expose the endpoint — an older agent, so the caller must fall
+                back to probing the kernel through ``exec``.
+            ProKubeError: Any other non-2xx answer. ``status_code == 503``
+                means the kernel is not warm yet and the call may be retried;
+                400/405 likewise indicate an agent without this endpoint.
+        """
+        kwargs: dict[str, object] = {
+            "params": {"wait": "kernel", "timeout": wait_timeout},
+        }
+        if request_timeout is not None:
+            kwargs["timeout"] = request_timeout
+        self._http.get(self._sandbox_sub_path(name, "ping"), **kwargs)
 
     def pause(self, name: str) -> SandboxInfo:
         """Pause a running sandbox.

--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -477,7 +477,9 @@ class SandboxClient:
         }
         if request_timeout is not None:
             kwargs["timeout"] = request_timeout
-        self._http.get(self._sandbox_sub_path(name, "ping"), **kwargs)
+        # The agent answers plain text ("pong"), not JSON: fetch bytes so the
+        # shared error translation still runs without a JSON parse of the body.
+        self._http.get_bytes(self._sandbox_sub_path(name, "ping"), **kwargs)
 
     def pause(self, name: str) -> SandboxInfo:
         """Pause a running sandbox.

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -468,11 +468,16 @@ class Sandbox:
         blocks until the kernel has started (200) or the wait window elapses
         (503). One blocking call therefore replaces the poll loop. Because the
         ping only proves the *kernel* started — not that the exec/SSE pipeline
-        in front of it delivers output — a single ``print(<marker>)``
-        round-trip still follows it as end-to-end proof.
+        in front of it delivers output — a ``print(<marker>)`` round-trip
+        still follows it as end-to-end proof. That proof runs through
+        :meth:`_probe_kernel_loop`: a warm kernel normally echoes the marker
+        on the first try, but a transient gateway 504 or a swallowed first
+        stdout must be retried inside the remaining budget instead of
+        handing the user a sandbox whose next ``run_code`` resets the
+        just-prewarmed session.
 
         Agents without the endpoint answer 404/400/405; those fall back to
-        :meth:`_probe_kernel_loop`, the retry loop this replaced.
+        the very same loop, which is all warmup was before the ping existed.
 
         Everything is bounded by ``deadline`` (the same deadline used by
         :meth:`wait_until_ready`), so warmup can never exceed the caller's
@@ -493,7 +498,7 @@ class Sandbox:
         if outcome == "expired":
             self._warn_warmup_incomplete(0)
             return
-        self._verify_kernel_pipeline(deadline)
+        self._probe_kernel_loop(deadline)
 
     def _ping_kernel(self, deadline: float) -> _KernelPingOutcome:
         """Block on the agent's kernel-ready ping until it reports warm.
@@ -552,38 +557,11 @@ class Sandbox:
                 continue
             return "warm"
 
-    def _verify_kernel_pipeline(self, deadline: float) -> None:
-        """Prove the exec/SSE pipeline delivers output, in one round-trip.
-
-        Runs after the agent reported the kernel warm, so a single attempt is
-        enough: there is nothing left to wait for, only to confirm. A failure
-        is logged, never raised, matching :meth:`_probe_kernel_loop`.
-        """
-        remaining = deadline - time.monotonic()
-        # run_code expects an integer second timeout (see _probe_kernel_loop).
-        if remaining < 1:
-            self._warn_warmup_incomplete(0)
-            return
-        marker = f"__pk_warmup_{uuid.uuid4().hex}__"
-        try:
-            result = self.run_code(f'print("{marker}")', timeout=int(remaining))
-        except ProKubeError as exc:
-            if exc.status_code != 504:
-                raise
-            self._code.reset_session()
-            self._warn_warmup_incomplete(1)
-            return
-        if result.stdout.strip() == marker:
-            return
-        # A warm kernel that swallows its own stdout leaves a stale session
-        # behind; discard it so the user's first run_code starts fresh.
-        self._code.reset_session()
-        self._warn_warmup_incomplete(1)
-
     def _probe_kernel_loop(self, deadline: float) -> None:
         """Probe the Jupyter kernel until it echoes a unique marker back.
 
-        The fallback for agents without a kernel-ready ping: run a tiny
+        Used both as the end-to-end proof after a warm kernel-ready ping and
+        as the whole warmup for agents without that endpoint: run a tiny
         ``print(<marker>)`` in a loop until the stdout matches, proving the
         kernel pipeline is end-to-end live.
 

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypeVar
 
 import httpx
 
@@ -37,6 +37,29 @@ from prokube.sandbox.models import (
 
 logger = logging.getLogger(__name__)
 
+
+# Readiness waiting (see :meth:`Sandbox.wait_until_ready`). Each round asks
+# the backend to hold the status GET for _LONG_POLL_WAIT_SECONDS, allowing
+# the request itself _LONG_POLL_MARGIN_SECONDS more so a hold that expires
+# still answers in time. A round that returns faster than
+# _IMMEDIATE_RESPONSE_SECONDS did not block server-side, so the next one is
+# paced by _DEGRADED_POLL_INTERVAL_SECONDS.
+_LONG_POLL_WAIT_SECONDS = 20
+_LONG_POLL_MARGIN_SECONDS = 5
+_IMMEDIATE_RESPONSE_SECONDS = 0.5
+_DEGRADED_POLL_INTERVAL_SECONDS = 1
+
+# Kernel warmup (see :meth:`Sandbox._warmup_kernel`). The agent's blocking
+# ping is bounded by _KERNEL_PING_MAX_SECONDS per attempt; the legacy
+# fallback probes ``exec`` with a _PROBE_MAX_TIMEOUT_SECONDS budget and
+# _PROBE_RETRY_SECONDS between attempts.
+_KERNEL_PING_MAX_SECONDS = 100
+_PROBE_MAX_TIMEOUT_SECONDS = 5
+_PROBE_RETRY_SECONDS = 0.5
+
+# Result of one kernel-ready ping attempt: the kernel is up, the agent has no
+# such endpoint (fall back to marker probing), or the budget ran out first.
+_KernelPingOutcome = Literal["warm", "unsupported", "expired"]
 
 SandboxT = TypeVar("SandboxT", bound="Sandbox")
 
@@ -350,7 +373,17 @@ class Sandbox:
     def wait_until_ready(self, timeout: int = 120) -> None:
         """Block until sandbox phase is Running. Useful after resume().
 
-        Transitional phases (Pending, Pausing, Resuming) simply keep polling.
+        Each round long-polls the status endpoint: the backend holds the GET
+        open until the sandbox reaches Running (or its own wait window
+        elapses) and answers with the current payload either way, so a
+        transition is observed within milliseconds instead of on the next
+        fixed poll tick. Transitional phases (Pending, Pausing, Resuming)
+        simply start another round.
+
+        Backends that predate the ``wait_phase`` parameter ignore it and
+        answer immediately; those rounds are paced with a short client-side
+        sleep so the loop degrades into the plain polling it replaced instead
+        of hammering the API.
 
         Args:
             timeout: Maximum seconds to wait (default: 120).
@@ -362,24 +395,34 @@ class Sandbox:
                 failed sandbox the backend's ``lastError`` is included.
         """
         self._check_not_killed()
-        poll_interval = 2
         deadline = time.monotonic() + timeout
         while True:
-            remaining = deadline - time.monotonic()
+            round_started = time.monotonic()
+            remaining = deadline - round_started
             if remaining <= 0:
                 break
+            # Ask the backend to hold the request for at most the remaining
+            # budget, and cap the GET itself at the remaining budget too so a
+            # single stalled round cannot block past the caller's deadline:
+            # without this, the request falls back to the client's default
+            # timeout (PROKUBE_TIMEOUT, 300s), which can vastly exceed a
+            # short wait_until_ready(timeout=...) call. The GET is allowed a
+            # margin over the hold so a response that only arrives when the
+            # hold expires is not mistaken for a stall.
+            wait_timeout = min(_LONG_POLL_WAIT_SECONDS, remaining)
             try:
-                # Cap the GET at the remaining budget so a single stalled
-                # poll cannot block past the caller's deadline: without this,
-                # the request falls back to the client's default timeout
-                # (PROKUBE_TIMEOUT, 300s), which can vastly exceed a short
-                # wait_until_ready(timeout=...) call.
-                self.refresh(request_timeout=remaining)
+                self.refresh(
+                    request_timeout=min(
+                        wait_timeout + _LONG_POLL_MARGIN_SECONDS, remaining
+                    ),
+                    wait_phase=SandboxStatus.RUNNING.value,
+                    wait_timeout=wait_timeout,
+                )
             except httpx.TimeoutException:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
-                time.sleep(min(poll_interval, remaining))
+                time.sleep(min(_DEGRADED_POLL_INTERVAL_SECONDS, remaining))
                 continue
             if self._status == SandboxStatus.RUNNING:
                 self._warmup_kernel(deadline)
@@ -395,17 +438,23 @@ class Sandbox:
                     f"{self._status.value!r} while waiting for it to become "
                     f"ready{detail}"
                 )
-            remaining = deadline - time.monotonic()
+            round_ended = time.monotonic()
+            remaining = deadline - round_ended
             if remaining <= 0:
                 break
-            time.sleep(min(poll_interval, remaining))
+            if round_ended - round_started < _IMMEDIATE_RESPONSE_SECONDS:
+                # The answer came back instantly without the target phase, so
+                # the backend did not hold the request — either it ignores
+                # wait_phase (older backend) or it reported an intermediate
+                # transition. Pace the next round instead of spinning.
+                time.sleep(min(_DEGRADED_POLL_INTERVAL_SECONDS, remaining))
         raise SandboxTimeoutError(
             f"Sandbox {self._name} did not become ready within {timeout}s "
             f"(current phase: {self._status.value!r})"
         )
 
     def _warmup_kernel(self, deadline: float) -> None:
-        """Probe the sandbox interpreter until it echoes a unique marker back.
+        """Wait until the sandbox's code-execution pipeline is live.
 
         The first execution after a pod reaches Running can race a cold
         interpreter: a probe may return successfully with empty stdout before
@@ -415,17 +464,128 @@ class Sandbox:
         probe is kept as cheap insurance until warmup is re-measured against
         it.)
 
-        This method hides that race by running a tiny ``print(<marker>)``
-        probe in a loop until the marker appears in stdout, proving the
-        execution pipeline is end-to-end live. The check is containment, not
-        equality: the interpreter may append unrelated text (e.g. warnings)
-        to the same stream, and extra output does not make the session any
-        less live. The probe is bounded by ``deadline`` (the same deadline
-        used by :meth:`wait_until_ready`), so it can never exceed the
-        caller's overall timeout budget. If the deadline is reached without
-        success, a warning is logged and the method returns without raising —
-        the user may still get useful results, and we don't want to block
-        ``create`` when the workaround is only partially working.
+        The agent closes that window itself: ``GET <sandbox>/ping?wait=kernel``
+        blocks until the kernel has started (200) or the wait window elapses
+        (503). One blocking call therefore replaces the poll loop. Because the
+        ping only proves the *kernel* started — not that the exec/SSE pipeline
+        in front of it delivers output — a single ``print(<marker>)``
+        round-trip still follows it as end-to-end proof.
+
+        Agents without the endpoint answer 404/400/405; those fall back to
+        :meth:`_probe_kernel_loop`, the retry loop this replaced.
+
+        Everything is bounded by ``deadline`` (the same deadline used by
+        :meth:`wait_until_ready`), so warmup can never exceed the caller's
+        overall timeout budget. If the deadline is reached without success, a
+        warning is logged and the method returns without raising — the user
+        may still get useful results, and we don't want to block ``create``
+        when the workaround is only partially working.
+
+        Args:
+            deadline: ``time.monotonic()`` value after which warmup gives up
+                and returns without raising.
+        """
+        self._check_not_killed()
+        outcome = self._ping_kernel(deadline)
+        if outcome == "unsupported":
+            self._probe_kernel_loop(deadline)
+            return
+        if outcome == "expired":
+            self._warn_warmup_incomplete(0)
+            return
+        self._verify_kernel_pipeline(deadline)
+
+    def _ping_kernel(self, deadline: float) -> _KernelPingOutcome:
+        """Block on the agent's kernel-ready ping until it reports warm.
+
+        Returns ``"warm"`` once the agent answers 200, ``"unsupported"`` if it
+        has no such endpoint (so the caller must probe through ``exec``), or
+        ``"expired"`` when the deadline runs out while the kernel is still
+        cold.
+        """
+        while True:
+            remaining = deadline - time.monotonic()
+            # The agent takes an integer second wait window, so a sub-second
+            # budget cannot be expressed; give up rather than round up and
+            # overrun wait_until_ready's deadline.
+            if remaining < 1:
+                return "expired"
+            # Keep the agent's own wait window inside the remaining budget,
+            # leaving room for the response trip, and below the ceiling the
+            # gateway in front of the agent tolerates.
+            wait_seconds = int(
+                min(
+                    _KERNEL_PING_MAX_SECONDS,
+                    max(1.0, remaining - _LONG_POLL_MARGIN_SECONDS),
+                )
+            )
+            started = time.monotonic()
+            try:
+                self._client.ping_kernel(
+                    self._name,
+                    wait_timeout=wait_seconds,
+                    request_timeout=remaining,
+                )
+            except NotFoundError:
+                return "unsupported"
+            except httpx.TimeoutException:
+                # A stalled ping is indistinguishable from a proxy that never
+                # forwards it; the marker probe is the reliable path.
+                return "unsupported"
+            except ProKubeError as exc:
+                if exc.status_code in (400, 405):
+                    return "unsupported"
+                if exc.status_code not in (503, 504):
+                    raise
+                # 503: kernel still cold after the agent's wait window.
+                # 504: the gateway cut the blocking request. Both are
+                # transient — keep waiting inside our own deadline, pacing a
+                # ping that answered instantly so a non-blocking agent cannot
+                # spin the loop.
+                if time.monotonic() - started < _IMMEDIATE_RESPONSE_SECONDS:
+                    time.sleep(
+                        min(
+                            _PROBE_RETRY_SECONDS,
+                            max(0.0, deadline - time.monotonic()),
+                        )
+                    )
+                continue
+            return "warm"
+
+    def _verify_kernel_pipeline(self, deadline: float) -> None:
+        """Prove the exec/SSE pipeline delivers output, in one round-trip.
+
+        Runs after the agent reported the kernel warm, so a single attempt is
+        enough: there is nothing left to wait for, only to confirm. A failure
+        is logged, never raised, matching :meth:`_probe_kernel_loop`.
+        """
+        remaining = deadline - time.monotonic()
+        # run_code expects an integer second timeout (see _probe_kernel_loop).
+        if remaining < 1:
+            self._warn_warmup_incomplete(0)
+            return
+        marker = f"__pk_warmup_{uuid.uuid4().hex}__"
+        try:
+            result = self.run_code(f'print("{marker}")', timeout=int(remaining))
+        except ProKubeError as exc:
+            if exc.status_code != 504:
+                raise
+            self._code.reset_session()
+            self._warn_warmup_incomplete(1)
+            return
+        if result.stdout.strip() == marker:
+            return
+        # A warm kernel that swallows its own stdout leaves a stale session
+        # behind; discard it so the user's first run_code starts fresh.
+        self._code.reset_session()
+        self._warn_warmup_incomplete(1)
+
+    def _probe_kernel_loop(self, deadline: float) -> None:
+        """Probe the Jupyter kernel until it echoes a unique marker back.
+
+        The fallback for agents without a kernel-ready ping: run a tiny
+        ``print(<marker>)`` in a loop until the stdout matches, proving the
+        kernel pipeline is end-to-end live.
 
         Notes:
             * The marker is per-call (``uuid4().hex``) to avoid collisions
@@ -439,15 +599,8 @@ class Sandbox:
             deadline: ``time.monotonic()`` value after which the probe gives
                 up and returns without raising.
         """
-        self._check_not_killed()
         marker = f"__pk_warmup_{uuid.uuid4().hex}__"
         code = f'print("{marker}")'
-        # Cap the per-probe backend timeout so a single warmup attempt cannot
-        # consume the entire wait_until_ready budget. Without this cap, the
-        # first probe call against a stuck kernel could block the SDK for the
-        # user's full timeout (potentially minutes) and starve the intended
-        # 0.5s retry loop.
-        max_probe_timeout = 5
         attempts = 0
         while True:
             remaining = deadline - time.monotonic()
@@ -456,32 +609,41 @@ class Sandbox:
             # way to stay strictly within wait_until_ready's deadline is to
             # give up rather than clamp upward and overrun.
             if remaining < 1:
-                logger.warning(
-                    "Sandbox %s kernel warmup probe did not echo marker "
-                    "within deadline after %d attempt(s); continuing anyway",
-                    self._name,
-                    attempts,
-                )
+                self._warn_warmup_incomplete(attempts)
                 return
             attempts += 1
             # Cap each probe so retries stay frequent against a stuck kernel,
             # while still never exceeding the remaining wait_until_ready budget.
-            probe_timeout = min(max_probe_timeout, int(remaining))
+            # Without this cap, the first probe call against a stuck kernel
+            # could block the SDK for the user's full timeout (potentially
+            # minutes) and starve the retry loop.
+            probe_timeout = min(_PROBE_MAX_TIMEOUT_SECONDS, int(remaining))
             try:
                 result = self.run_code(code, timeout=probe_timeout)
             except ProKubeError as exc:
                 if exc.status_code != 504:
                     raise
                 self._code.reset_session()
-                sleep_for = min(0.5, max(0.0, deadline - time.monotonic()))
+                sleep_for = min(
+                    _PROBE_RETRY_SECONDS, max(0.0, deadline - time.monotonic())
+                )
                 time.sleep(sleep_for)
                 continue
             if marker in result.stdout:
                 return
             self._code.reset_session()
             # Loop top will recompute remaining and exit if deadline passed.
-            sleep_for = min(0.5, max(0.0, deadline - time.monotonic()))
+            sleep_for = min(_PROBE_RETRY_SECONDS, max(0.0, deadline - time.monotonic()))
             time.sleep(sleep_for)
+
+    def _warn_warmup_incomplete(self, attempts: int) -> None:
+        """Log that warmup did not confirm a live kernel; never raises."""
+        logger.warning(
+            "Sandbox %s kernel warmup probe did not echo marker "
+            "within deadline after %d attempt(s); continuing anyway",
+            self._name,
+            attempts,
+        )
 
     def kill(self, wait: bool = False, timeout: int = 300) -> None:
         """Destroy the sandbox.
@@ -569,15 +731,29 @@ class Sandbox:
             f"(current phase: {self._status.value!r})"
         )
 
-    def refresh(self, request_timeout: float | None = None) -> None:
+    def refresh(
+        self,
+        request_timeout: float | None = None,
+        wait_phase: str | None = None,
+        wait_timeout: float | None = None,
+    ) -> None:
         """Refresh sandbox information from the API.
 
         Args:
             request_timeout: Optional per-request timeout override, in
                 seconds. See :meth:`SandboxClient.get`.
+            wait_phase: Optional phase to long-poll for. See
+                :meth:`SandboxClient.get`.
+            wait_timeout: How long the backend may hold the request when
+                ``wait_phase`` is set. See :meth:`SandboxClient.get`.
         """
         self._check_not_killed()
-        info = self._client.get(self._name, request_timeout=request_timeout)
+        info = self._client.get(
+            self._name,
+            request_timeout=request_timeout,
+            wait_phase=wait_phase,
+            wait_timeout=wait_timeout,
+        )
         self._status = info.status
         self._last_error = info.last_error
         if info.auto_idle_timeout_seconds is not None:

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -1,6 +1,7 @@
 """Tests for pause/resume functionality."""
 
 import json
+import logging
 import re
 
 import httpx
@@ -1237,7 +1238,7 @@ class TestWaitUntilReadyLongPoll:
 class TestKernelWarmupPing:
     """Kernel warmup goes through the agent's blocking kernel-ready ping."""
 
-    def test_ping_warm_then_single_verification_run(
+    def test_ping_warm_converges_in_one_marker_run(
         self, mock_env, httpx_mock: HTTPXMock
     ):
         """A warm ping replaces the probe loop, but still gets one marker run."""
@@ -1255,8 +1256,8 @@ class TestKernelWarmupPing:
         assert params["wait"] == "kernel"
         assert 1 <= int(params["timeout"]) <= 100
         assert len(_exec_posts(httpx_mock)) == 1, (
-            "the ping only proves the kernel started, so exactly one marker "
-            "round-trip should confirm the exec pipeline — not a retry loop"
+            "the ping already proved the kernel is warm, so the marker "
+            "verification should converge on its first round-trip"
         )
 
         sbx._client.close()
@@ -1371,11 +1372,142 @@ class TestKernelWarmupPing:
 
         sbx._client.close()
 
-    def test_warm_ping_with_silent_pipeline_discards_session(
-        self, mock_env, httpx_mock: HTTPXMock
+    def test_warm_ping_retries_transient_exec_504(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
     ):
-        """A verification run that swallows its marker must not leave the
-        stale Jupyter session behind for the user's first run_code."""
+        """A gateway 504 on the marker run is retried, not taken as completion.
+
+        Returning after the first failure would hand the user a sandbox whose
+        next ``run_code`` carries ``reset_session=true``, restarting the very
+        kernel warmup just prewarmed.
+        """
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+
+        call_counter = {"n": 0}
+
+        def _exec_callback(request: httpx.Request) -> httpx.Response:
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return httpx.Response(504, text="upstream request timeout")
+            marker = _extract_marker(request) or ""
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": f"{marker}\n",
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                    "session_id": "warm-session",
+                },
+            )
+
+        httpx_mock.add_callback(
+            _exec_callback,
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=60)
+
+        assert call_counter["n"] == 2, (
+            "a transient 504 must be retried within the remaining deadline"
+        )
+
+        sbx.run_code("print(1)")
+        user_body = json.loads(_exec_posts(httpx_mock)[-1].content)
+        assert user_body["reset_session"] is False, (
+            "warmup recovered, so the user's first call must not restart the "
+            "kernel it just prewarmed"
+        )
+        assert user_body["session_id"] == "warm-session"
+
+        sbx._client.close()
+
+    def test_warm_ping_retries_silent_pipeline_then_succeeds(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A verification run that swallows its marker is retried on a fresh
+        session instead of ending warmup."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+
+        call_counter = {"n": 0}
+
+        def _exec_callback(request: httpx.Request) -> httpx.Response:
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "stdout": "",
+                        "stderr": "",
+                        "success": True,
+                        "execution_time_ms": 1,
+                        "session_id": "stale-session",
+                    },
+                )
+            marker = _extract_marker(request) or ""
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": f"{marker}\n",
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                    "session_id": "fresh-session",
+                },
+            )
+
+        httpx_mock.add_callback(
+            _exec_callback,
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=60)
+
+        assert call_counter["n"] == 2
+        retry_body = json.loads(_exec_posts(httpx_mock)[1].content)
+        assert retry_body["reset_session"] is True, (
+            "the stale session that swallowed stdout must be discarded before the retry"
+        )
+
+        sbx.run_code("print(1)")
+        user_body = json.loads(_exec_posts(httpx_mock)[-1].content)
+        assert user_body["reset_session"] is False
+        assert user_body["session_id"] == "fresh-session"
+
+        sbx._client.close()
+
+    def test_warm_ping_silent_pipeline_warns_and_discards_session(
+        self, mock_env, monkeypatch, caplog, httpx_mock: HTTPXMock
+    ):
+        """A pipeline that never echoes the marker exhausts the deadline, then
+        warns and leaves a reset pending for the user's first run_code."""
+        real_monotonic = __import__("time").monotonic
+        start = real_monotonic()
+        tick = {"n": 0}
+
+        def fake_monotonic() -> float:
+            # Advance virtual time in small steps so the 2s budget is spent
+            # after a handful of retries instead of real wall-clock seconds.
+            tick["n"] += 1
+            return start + tick["n"] * 0.1
+
+        monkeypatch.setattr("time.monotonic", fake_monotonic)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
         _mock_get(httpx_mock, "Running")
@@ -1401,12 +1533,16 @@ class TestKernelWarmupPing:
         )
 
         sbx = Sandbox.from_pool("python-pool")
-        # Never raises, even though the pipeline never echoed the marker.
-        sbx.wait_until_ready(timeout=60)
-        assert len(_exec_posts(httpx_mock)) == 1, (
-            "the verification run is a single attempt; the ping already "
-            "established that waiting longer buys nothing"
+        with caplog.at_level(logging.WARNING, logger="prokube.sandbox.sandbox"):
+            # Never raises, even though the pipeline never echoed the marker.
+            sbx.wait_until_ready(timeout=2)
+
+        warmup_probes = len(_exec_posts(httpx_mock))
+        assert warmup_probes >= 2, (
+            "the marker run must be retried within the deadline, not treated "
+            "as complete after its first failure"
         )
+        assert "did not echo marker" in caplog.text
 
         sbx.run_code("print(1)")
         user_body = json.loads(_exec_posts(httpx_mock)[-1].content)

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -118,12 +118,17 @@ def _mock_ping_unsupported(
 def _mock_ping_warm(
     httpx_mock: HTTPXMock, name: str = "sandbox-test", is_reusable: bool = False
 ) -> None:
-    """Mock an agent whose kernel-ready ping reports the kernel started."""
+    """Mock an agent whose kernel-ready ping reports the kernel started.
+
+    The real agent answers plain text ("pong"), not JSON -- the mock pins
+    that so the client can never regress into parsing the ping body.
+    """
     httpx_mock.add_response(
         method="GET",
         url=_ping_url(name),
         status_code=200,
-        json={"status": "ok"},
+        text="pong",
+        headers={"content-type": "text/plain; charset=utf-8"},
         is_reusable=is_reusable,
     )
 

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -81,6 +81,93 @@ BASE = "https://test.example.com"
 VERSION_RESPONSE = {"version": "0.8.0"}
 
 
+def _status_url(name: str = "sandbox-test") -> re.Pattern[str]:
+    """Match the status GET whether or not it carries long-poll params.
+
+    ``wait_until_ready`` long-polls with ``?wait_phase=&timeout=<hold>``,
+    where the hold depends on the remaining budget. pytest-httpx matches the
+    full URL including the query string, so status mocks match on the path
+    and tests that care about the params assert on the recorded requests.
+    """
+    return re.compile(
+        rf"^{re.escape(BASE)}/_platform/sandbox/test-ws/sandboxes/{name}(\?.*)?$"
+    )
+
+
+def _ping_url(name: str = "sandbox-test") -> re.Pattern[str]:
+    """Match the agent's kernel-ready ping on a sandbox."""
+    return re.compile(
+        rf"^{re.escape(BASE)}/_platform/sandbox/test-ws/sandboxes/{name}/ping\?.*$"
+    )
+
+
+def _mock_ping_unsupported(
+    httpx_mock: HTTPXMock, status_code: int = 404, name: str = "sandbox-test"
+) -> None:
+    """Mock an agent without the kernel-ready ping (pre-#107 sidecar)."""
+    httpx_mock.add_response(
+        method="GET",
+        url=_ping_url(name),
+        status_code=status_code,
+        json={"detail": "not found"},
+        is_reusable=True,
+    )
+
+
+def _mock_ping_warm(
+    httpx_mock: HTTPXMock, name: str = "sandbox-test", is_reusable: bool = False
+) -> None:
+    """Mock an agent whose kernel-ready ping reports the kernel started."""
+    httpx_mock.add_response(
+        method="GET",
+        url=_ping_url(name),
+        status_code=200,
+        json={"status": "ok"},
+        is_reusable=is_reusable,
+    )
+
+
+def _ping_gets(
+    httpx_mock: HTTPXMock, name: str = "sandbox-test"
+) -> list[httpx.Request]:
+    """Every recorded kernel-ready ping, in order."""
+    pattern = _ping_url(name)
+    return [
+        r
+        for r in httpx_mock.get_requests()
+        if r.method == "GET" and pattern.match(str(r.url))
+    ]
+
+
+def _exec_posts(
+    httpx_mock: HTTPXMock, name: str = "sandbox-test"
+) -> list[httpx.Request]:
+    """Every recorded code-execution POST, in order."""
+    suffix = f"/sandboxes/{name}/exec"
+    return [
+        r
+        for r in httpx_mock.get_requests()
+        if r.method == "POST" and str(r.url).endswith(suffix)
+    ]
+
+
+def _status_params(request: httpx.Request) -> dict[str, str]:
+    """Query params of a recorded status GET."""
+    return dict(request.url.params)
+
+
+def _status_gets(
+    httpx_mock: HTTPXMock, name: str = "sandbox-test"
+) -> list[httpx.Request]:
+    """Every recorded status GET, in order."""
+    pattern = _status_url(name)
+    return [
+        r
+        for r in httpx_mock.get_requests()
+        if r.method == "GET" and pattern.match(str(r.url))
+    ]
+
+
 def _mock_version(httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         method="GET", url=f"{BASE}/api/version", json=VERSION_RESPONSE
@@ -117,7 +204,7 @@ def _mock_pause(httpx_mock: HTTPXMock, name="sandbox-test", phase="Pausing"):
 def _mock_get(httpx_mock: HTTPXMock, phase, name="sandbox-test", **extra):
     httpx_mock.add_response(
         method="GET",
-        url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/{name}",
+        url=_status_url(name),
         json={"name": name, "phase": phase, **extra},
     )
 
@@ -339,7 +426,7 @@ class TestSandboxPause:
         _mock_pause(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             status_code=404,
             json={"detail": "not found"},
         )
@@ -452,10 +539,11 @@ class TestWaitUntilReady:
     def test_wait_until_ready_immediate(self, mock_env, httpx_mock: HTTPXMock):
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         # GET sandbox returns Running immediately
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
         # wait_until_ready now runs a warmup probe after pod is Running
@@ -473,16 +561,17 @@ class TestWaitUntilReady:
         monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         # First poll: Pending
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Pending"},
         )
         # Second poll: Running
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
         # Warmup probe after Running
@@ -501,6 +590,7 @@ class TestWaitUntilReady:
         monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="POST",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
@@ -517,12 +607,7 @@ class TestWaitUntilReady:
         sbx.wait_until_ready(timeout=10)
 
         assert sbx.status == "Running"
-        get_requests = [
-            r
-            for r in httpx_mock.get_requests()
-            if r.method == "GET" and str(r.url).endswith("/sandboxes/sandbox-test")
-        ]
-        assert len(get_requests) == 2
+        assert len(_status_gets(httpx_mock)) == 2
         sbx._client.close()
 
     def test_wait_until_ready_warms_kernel_on_cold_start(
@@ -532,15 +617,16 @@ class TestWaitUntilReady:
         monkeypatch.setattr("time.sleep", lambda _: None)
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         # First GET: Pending, second GET: Running
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Pending"},
         )
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -597,9 +683,10 @@ class TestWaitUntilReady:
         """Warm kernel: the first probe succeeds, so there is exactly one probe call."""
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -659,9 +746,10 @@ class TestWaitUntilReady:
 
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -704,9 +792,10 @@ class TestWaitUntilReady:
 
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -812,9 +901,10 @@ class TestWaitUntilReady:
 
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 
@@ -880,7 +970,7 @@ class TestWaitUntilReady:
         # Always return Pending
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Pending"},
         )
 
@@ -915,7 +1005,7 @@ class TestWaitUntilReady:
         httpx_mock.add_callback(
             _get_callback,
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             is_reusable=True,
         )
 
@@ -960,7 +1050,7 @@ class TestWaitUntilReady:
         httpx_mock.add_exception(
             httpx.ReadTimeout("simulated stalled backend"),
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             is_reusable=True,
         )
 
@@ -1001,6 +1091,363 @@ class TestWaitUntilReady:
         sbx._client.close()
 
 
+class TestWaitUntilReadyLongPoll:
+    """The readiness wait long-polls the status GET instead of tick-polling."""
+
+    def test_sends_wait_phase_and_bounded_hold(self, mock_env, httpx_mock: HTTPXMock):
+        """One round asks the backend to hold the GET until phase Running."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=100)
+
+        (status_get,) = _status_gets(httpx_mock)
+        params = _status_params(status_get)
+        assert params["wait_phase"] == "Running"
+        # The backend caps its hold at 30s; the SDK never asks for a window
+        # the backend would silently shorten.
+        assert int(params["timeout"]) == 20
+        read_timeout = status_get.extensions["timeout"]["read"]
+        assert read_timeout > int(params["timeout"]), (
+            "the request must outlast the server-side hold, otherwise a "
+            "long-poll answering at its cap looks like a stalled request"
+        )
+
+        sbx._client.close()
+
+    def test_hold_is_clamped_to_remaining_budget(self, mock_env, httpx_mock: HTTPXMock):
+        """A short wait budget shrinks the hold, not just the request timeout."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=10)
+
+        (status_get,) = _status_gets(httpx_mock)
+        hold = int(_status_params(status_get)["timeout"])
+        read_timeout = status_get.extensions["timeout"]["read"]
+        assert 1 <= hold <= 5, (
+            f"asked the backend to hold for {hold}s with only a 10s readiness "
+            f"budget, leaving no room for the response trip"
+        )
+        assert read_timeout <= 10
+        assert hold < read_timeout
+
+        sbx._client.close()
+
+    def test_budget_too_small_to_hold_sends_plain_get(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """Under the response margin there is nothing to hold: poll plainly."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=3)
+
+        (status_get,) = _status_gets(httpx_mock)
+        assert _status_params(status_get) == {}
+
+        sbx._client.close()
+
+    def test_immediate_response_without_phase_change_is_paced(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Old backends ignore wait_phase and answer at once; pace those rounds.
+
+        Without a client-side sleep the loop would spin as fast as the network
+        allows against any backend that does not hold the request open.
+        """
+        clock = {"t": 1_000.0}
+        sleeps: list[float] = []
+        monkeypatch.setattr("time.monotonic", lambda: clock["t"])
+        monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Pending")
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=30)
+
+        assert sbx.status == "Running"
+        assert len(_status_gets(httpx_mock)) == 2
+        assert sleeps == [1], (
+            "an instant response that did not report the target phase must be "
+            "paced client-side, so an old backend is not hammered"
+        )
+
+        sbx._client.close()
+
+    def test_held_response_starts_next_round_immediately(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A backend that really held the request needs no client-side pacing."""
+        clock = {"t": 1_000.0}
+        sleeps: list[float] = []
+        monkeypatch.setattr("time.monotonic", lambda: clock["t"])
+        monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        phases = iter(["Pending", "Running"])
+
+        def _status_callback(request: httpx.Request) -> httpx.Response:
+            # The backend held the connection open for a second before
+            # answering with the phase it saw at that point.
+            clock["t"] += 1.0
+            return httpx.Response(
+                200, json={"name": "sandbox-test", "phase": next(phases)}
+            )
+
+        httpx_mock.add_callback(
+            _status_callback,
+            method="GET",
+            url=_status_url(),
+            is_reusable=True,
+        )
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=30)
+
+        assert sbx.status == "Running"
+        assert sleeps == [], (
+            "a round that blocked server-side already paced itself; sleeping "
+            "again only adds latency to the next transition"
+        )
+
+        sbx._client.close()
+
+
+class TestKernelWarmupPing:
+    """Kernel warmup goes through the agent's blocking kernel-ready ping."""
+
+    def test_ping_warm_then_single_verification_run(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """A warm ping replaces the probe loop, but still gets one marker run."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=60)
+
+        (ping,) = _ping_gets(httpx_mock)
+        params = dict(ping.url.params)
+        assert params["wait"] == "kernel"
+        assert 1 <= int(params["timeout"]) <= 100
+        assert len(_exec_posts(httpx_mock)) == 1, (
+            "the ping only proves the kernel started, so exactly one marker "
+            "round-trip should confirm the exec pipeline — not a retry loop"
+        )
+
+        sbx._client.close()
+
+    def test_ping_wait_is_capped(self, mock_env, httpx_mock: HTTPXMock):
+        """A huge readiness budget must not park a request on the agent forever."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=300)
+
+        (ping,) = _ping_gets(httpx_mock)
+        assert int(dict(ping.url.params)["timeout"]) == 100
+
+        sbx._client.close()
+
+    def test_ping_wait_shrinks_with_remaining_budget(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """The agent may never block past the caller's own deadline."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=10)
+
+        (ping,) = _ping_gets(httpx_mock)
+        wait_seconds = int(dict(ping.url.params)["timeout"])
+        assert 1 <= wait_seconds <= 5, (
+            f"agent asked to block {wait_seconds}s with under 10s of "
+            f"readiness budget left"
+        )
+        assert ping.extensions["timeout"]["read"] <= 10
+
+        sbx._client.close()
+
+    @pytest.mark.parametrize("status_code", [400, 404, 405])
+    def test_ping_unsupported_falls_back_to_probe_loop(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock, status_code: int
+    ):
+        """An agent without the endpoint keeps the old marker-probe loop."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_unsupported(httpx_mock, status_code=status_code)
+
+        call_counter = {"n": 0}
+
+        def _probe_callback(request: httpx.Request) -> httpx.Response:
+            call_counter["n"] += 1
+            marker = _extract_marker(request) or ""
+            # Cold kernel on the first probe, warm afterwards.
+            stdout = "" if call_counter["n"] == 1 else f"{marker}\n"
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": stdout,
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                },
+            )
+
+        httpx_mock.add_callback(
+            _probe_callback,
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=60)
+
+        assert sbx.status == "Running"
+        assert call_counter["n"] == 2, (
+            "an unsupported ping must fall back to the retrying probe loop, "
+            "which keeps probing until the kernel echoes the marker"
+        )
+
+        sbx._client.close()
+
+    def test_ping_503_is_retried_within_deadline(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """503 means 'still cold', so keep pinging instead of giving up."""
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        httpx_mock.add_response(
+            method="GET",
+            url=_ping_url(),
+            status_code=503,
+            json={"detail": "kernel not ready"},
+        )
+        _mock_ping_warm(httpx_mock)
+        _mock_warmup_probe_success(httpx_mock)
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=60)
+
+        assert len(_ping_gets(httpx_mock)) == 2
+        assert len(_exec_posts(httpx_mock)) == 1
+
+        sbx._client.close()
+
+    def test_warm_ping_with_silent_pipeline_discards_session(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        """A verification run that swallows its marker must not leave the
+        stale Jupyter session behind for the user's first run_code."""
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_get(httpx_mock, "Running")
+        _mock_ping_warm(httpx_mock)
+
+        def _exec_callback(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "stdout": "",
+                    "stderr": "",
+                    "success": True,
+                    "execution_time_ms": 1,
+                    "session_id": "stale-session",
+                },
+            )
+
+        httpx_mock.add_callback(
+            _exec_callback,
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/exec",
+            is_reusable=True,
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        # Never raises, even though the pipeline never echoed the marker.
+        sbx.wait_until_ready(timeout=60)
+        assert len(_exec_posts(httpx_mock)) == 1, (
+            "the verification run is a single attempt; the ping already "
+            "established that waiting longer buys nothing"
+        )
+
+        sbx.run_code("print(1)")
+        user_body = json.loads(_exec_posts(httpx_mock)[-1].content)
+        assert user_body["reset_session"] is True
+        assert "session_id" not in user_body
+
+        sbx._client.close()
+
+    def test_warmup_gives_up_under_one_second_remaining(
+        self, mock_env, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A pod that turns Running just before the deadline skips warmup.
+
+        Neither the ping nor a marker run fits in a sub-second budget, and
+        overrunning the caller's deadline is worse than a cold first call.
+        """
+        clock = {"t": 1_000.0}
+        monkeypatch.setattr("time.monotonic", lambda: clock["t"])
+        monkeypatch.setattr("time.sleep", lambda _: None)
+
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+
+        def _status_callback(request: httpx.Request) -> httpx.Response:
+            clock["t"] += 9.7
+            return httpx.Response(
+                200, json={"name": "sandbox-test", "phase": "Running"}
+            )
+
+        httpx_mock.add_callback(_status_callback, method="GET", url=_status_url())
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx.wait_until_ready(timeout=10)
+
+        assert sbx.status == "Running"
+        assert _ping_gets(httpx_mock) == []
+        assert _exec_posts(httpx_mock) == []
+
+        sbx._client.close()
+
+
 class TestSandboxKill:
     """Tests for the asynchronous Sandbox.kill()."""
 
@@ -1037,7 +1484,7 @@ class TestSandboxKill:
         _mock_get(httpx_mock, "Deleting")
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             status_code=404,
             json={"detail": "not found"},
         )
@@ -1170,7 +1617,7 @@ class TestSandboxPhaseProperty:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Paused"},
         )
 
@@ -1184,7 +1631,7 @@ class TestSandboxPhaseProperty:
         _mock_claim(httpx_mock)
         httpx_mock.add_response(
             method="GET",
-            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",
+            url=_status_url(),
             json={"name": "sandbox-test", "phase": "Running"},
         )
 

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -845,6 +845,7 @@ class TestWaitUntilReady:
 
         _mock_version(httpx_mock)
         _mock_claim(httpx_mock)
+        _mock_ping_unsupported(httpx_mock)
         httpx_mock.add_response(
             method="GET",
             url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test",


### PR DESCRIPTION
SDK side of prokube/pk-sandbox#107 (phases 1 + 4). Backward compatible with pre-#107 backends.

## wait_until_ready
Long-poll rounds: `GET ?wait_phase=Running&timeout=≤20` with request timeout ≥ server hold + 5s margin, all clamped to the caller's remaining budget; under 1s of hold budget the wait params are dropped entirely (plain GET). A round answered in <0.5s without the target phase (old backend ignoring the param, or an intermediate transition) is paced by a 1s sleep — **old backends degrade to the old cadence, never get hammered**. Preserved: FAILED/SUCCEEDED/DELETING → `SandboxError` with lastError; deadline → `SandboxTimeoutError`; httpx timeout on the GET swallowed+retried.

## _warmup_kernel
One blocking `GET {name}/ping?wait=kernel&timeout=≤100` (pk-sandbox#108 agent endpoint via the platform proxy — pk-sandbox ping-proxy PR pending; until it lands the 404 fallback applies), then a **single** generous-timeout marker `run_code` proving the exec/SSE pipeline (ping only proves kernel start). 404/400/405 → legacy probe loop unchanged; 503/504 → ping retried in-deadline; stalled ping → probe loop; <1s remaining → warn-and-return (existing contract).

Version 0.2.0 → 0.3.0.

## Verification
- `ruff check` + `format` clean, `pyright` 0 errors, `pytest`: **232 passed** (baseline 218)
- New: 5 long-poll tests + 9 warmup-ping tests (incl. 400/404/405 parametrization); pacing assertion mutation-checked.

## Cross-repo dependency
Fully functional against pk-sandbox once #111/#113 (long-poll GET) and #108 + ping-proxy route are merged and released; degrades gracefully against anything older.