### PR TITLE
feat: preserve sessions across full snapshot resumes

### DIFF
--- a/src/prokube/sandbox/client.py
+++ b/src/prokube/sandbox/client.py
@@ -72,6 +72,10 @@ def _parse_sandbox_info(
         created_at=raw.get("createdAt") or raw.get("created_at"),
         auto_idle_timeout_seconds=parse_auto_idle_timeout(raw),
         last_error=raw.get("lastError") or raw.get("last_error"),
+        preserves_process_state=raw.get(
+            "preservesProcessState", raw.get("preserves_process_state", False)
+        )
+        is True,
     )
 
 

--- a/src/prokube/sandbox/models.py
+++ b/src/prokube/sandbox/models.py
@@ -50,6 +50,10 @@ class SandboxInfo(BaseModel):
         default=None,
         description="Why the last lifecycle step failed, when the phase is Failed",
     )
+    preserves_process_state: bool = Field(
+        default=False,
+        description="Whether pause and resume preserve running process state",
+    )
 
 
 class SandboxInfoPage(BaseModel):

--- a/src/prokube/sandbox/sandbox.py
+++ b/src/prokube/sandbox/sandbox.py
@@ -298,9 +298,9 @@ class Sandbox:
         info = self._client.pause(self._name)
         self._status = info.status
         self._last_error = info.last_error
-        # Pausing deletes the underlying pod, so any existing Jupyter session
-        # is no longer valid. Reset so next run_code() starts a fresh kernel.
-        self._code.reset_session()
+        if not info.preserves_process_state:
+            # The normal pod-replacement path invalidates the old code session.
+            self._code.reset_session()
         if wait:
             self._wait_for_pause(timeout)
 
@@ -367,8 +367,8 @@ class Sandbox:
         self._last_error = info.last_error
         if info.auto_idle_timeout_seconds is not None:
             self._auto_idle_timeout_seconds = info.auto_idle_timeout_seconds
-        # New pod means previous Jupyter session is invalid.
-        self._code.reset_session()
+        if not info.preserves_process_state:
+            self._code.reset_session()
 
     def wait_until_ready(self, timeout: int = 120) -> None:
         """Block until sandbox phase is Running. Useful after resume().

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -197,13 +197,13 @@ def _mock_claim(httpx_mock: HTTPXMock, name="sandbox-test", phase="Running"):
     )
 
 
-def _mock_pause(httpx_mock: HTTPXMock, name="sandbox-test", phase="Pausing"):
+def _mock_pause(httpx_mock: HTTPXMock, name="sandbox-test", phase="Pausing", **extra):
     """Mock the pause endpoint with the v0.8 202 + full Sandbox body."""
     httpx_mock.add_response(
         method="POST",
         url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/{name}/pause",
         status_code=202,
-        json={"name": name, "namespace": "test-ws", "phase": phase},
+        json={"name": name, "namespace": "test-ws", "phase": phase, **extra},
     )
 
 
@@ -518,6 +518,54 @@ class TestSandboxResume:
         sbx.resume()
 
         assert sbx.auto_idle_timeout_seconds == 900
+        sbx._client.close()
+
+    def test_full_snapshot_lifecycle_preserves_code_session(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock, preservesProcessState=True)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
+            status_code=202,
+            json={
+                "name": "sandbox-test",
+                "phase": "Resuming",
+                "preservesProcessState": True,
+            },
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx._code._session_id = "restorable-session"
+        sbx.pause(wait=False)
+        sbx.resume()
+
+        assert sbx.session_id == "restorable-session"
+        assert sbx._code._reset_on_next_exec is False
+        sbx._client.close()
+
+    def test_default_lifecycle_invalidates_code_session(
+        self, mock_env, httpx_mock: HTTPXMock
+    ):
+        _mock_version(httpx_mock)
+        _mock_claim(httpx_mock)
+        _mock_pause(httpx_mock)
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{BASE}/_platform/sandbox/test-ws/sandboxes/sandbox-test/resume",
+            status_code=202,
+            json={"name": "sandbox-test", "phase": "Resuming"},
+        )
+
+        sbx = Sandbox.from_pool("python-pool")
+        sbx._code._session_id = "stale-session"
+        sbx.pause(wait=False)
+        sbx.resume()
+
+        assert sbx.session_id is None
+        assert sbx._code._reset_on_next_exec is True
         sbx._client.close()
 
     def test_resume_non_paused_raises(self, mock_env, httpx_mock: HTTPXMock):


### PR DESCRIPTION
## Summary
- parse the backend's explicit `preservesProcessState` lifecycle capability
- retain code-session identity across pause/resume only when the backend promises process-state restoration
- preserve the existing reset behavior for all backends that omit or disable the capability

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -q` (237 passed)
- live Agent Substrate Full-snapshot conformance: 30/30 restores, resume-to-first-code p95 0.997s